### PR TITLE
Add currently used ISIS schemas

### DIFF
--- a/schemas/iH03_isis_events.fbs
+++ b/schemas/iH03_isis_events.fbs
@@ -28,28 +28,28 @@ union SEValue { IntValue, LongValue, DoubleValue, StringValue }
 // isis neutron events list
 table NEvents {
     tof : [float];
-  	spec : [int];
+    spec : [int];
 }
 
 // sample environment events log
 table SEEvent {
     name : string; // name of seci block / NXlog entry
     time_offset : float; // from start of run
-  	value : SEValue;
+    value : SEValue;
 }
 
 // (part of) an ISIS pulse/frame, there may be several of these
 // per frame to keep kafka packets to optimum size
 table FramePart {
     frame_number : int;
-  	frame_time : float;
-  	run_state : RunState;
-  	proton_charge : float;
-  	period : int; // DAE period number
-  	end_of_frame : bool = false; // true for last frame "part"
-  	end_of_run : bool = false; // true when final frame of data collection run
-  	n_events : NEvents;
-  	se_events : [SEEvent];
+    frame_time : float;
+    run_state : RunState;
+    proton_charge : float;
+    period : int; // DAE period number
+    end_of_frame : bool = false; // true for last frame "part"
+    end_of_run : bool = false; // true when final frame of data collection run
+    n_events : NEvents;
+    se_events : [SEEvent];
 }
 
 union MessageTypes { FramePart, RunInfo }

--- a/schemas/iH03_isis_events.fbs
+++ b/schemas/iH03_isis_events.fbs
@@ -1,0 +1,62 @@
+// schema for ISIS data streaming test
+
+include "run_info_schema.fbs";
+
+namespace ISISStream;
+
+enum RunState : byte { SETUP=0, RUNNING=1 }
+
+table IntValue {
+    value : int;
+}
+
+table LongValue {
+    value : long;
+}
+
+table DoubleValue {
+    value : double;
+}
+
+table StringValue {
+    value : string;
+}
+
+// for storing a sample environment log value
+union SEValue { IntValue, LongValue, DoubleValue, StringValue }
+
+// isis neutron events list
+table NEvents {
+    tof : [float];
+  	spec : [int];
+}
+
+// sample environment events log
+table SEEvent {
+    name : string; // name of seci block / NXlog entry
+    time_offset : float; // from start of run
+  	value : SEValue;
+}
+
+// (part of) an ISIS pulse/frame, there may be several of these
+// per frame to keep kafka packets to optimum size
+table FramePart {
+    frame_number : int;
+  	frame_time : float;
+  	run_state : RunState;
+  	proton_charge : float;
+  	period : int; // DAE period number
+  	end_of_frame : bool = false; // true for last frame "part"
+  	end_of_run : bool = false; // true when final frame of data collection run
+  	n_events : NEvents;
+  	se_events : [SEEvent];
+}
+
+union MessageTypes { FramePart, RunInfo }
+
+table EventMessage {
+    message : MessageTypes;
+    id : ulong;
+}
+
+root_type EventMessage;

--- a/schemas/iH03_isis_events.fbs
+++ b/schemas/iH03_isis_events.fbs
@@ -1,26 +1,15 @@
 // schema for ISIS data streaming test
 
-include "run_info_schema.fbs";
+include "iH04_isis_run_info.fbs";
 
 namespace ISISStream;
 
 enum RunState : byte { SETUP=0, RUNNING=1 }
 
-table IntValue {
-    value : int;
-}
-
-table LongValue {
-    value : long;
-}
-
-table DoubleValue {
-    value : double;
-}
-
-table StringValue {
-    value : string;
-}
+table IntValue { value : int; }
+table LongValue { value : long; }
+table DoubleValue { value : double; }
+table StringValue { value : string; }
 
 // for storing a sample environment log value
 union SEValue { IntValue, LongValue, DoubleValue, StringValue }

--- a/schemas/iH04_isis_run_info.fbs
+++ b/schemas/iH04_isis_run_info.fbs
@@ -1,0 +1,15 @@
+// schema for ISIS data streaming test
+
+namespace ISISStream;
+
+// this will be used in a separate kafka topic, used to pick up where current run starts
+// if you join late
+table RunInfo {
+    start_time : ulong;
+  	run_number : int;
+  	inst_name : string;
+  	stream_offset : long;   // offset into kafka topic for start of current data collection run
+  	n_periods : int;
+}
+
+root_type RunInfo;

--- a/schemas/iH04_isis_run_info.fbs
+++ b/schemas/iH04_isis_run_info.fbs
@@ -6,10 +6,10 @@ namespace ISISStream;
 // if you join late
 table RunInfo {
     start_time : ulong;
-  	run_number : int;
-  	inst_name : string;
-  	stream_offset : long;   // offset into kafka topic for start of current data collection run
-  	n_periods : int;
+    run_number : int;
+    inst_name : string;
+    stream_offset : long;   // offset into kafka topic for start of current data collection run
+    n_periods : int;
 }
 
 root_type RunInfo;

--- a/schemas/iH05_isis_det_spec_map.fbs
+++ b/schemas/iH05_isis_det_spec_map.fbs
@@ -1,0 +1,13 @@
+// schema for ISIS data streaming test
+
+namespace ISISStream;
+
+// this will be used in a separate kafka topic, used to pick up relevant wiring tables
+// this stream will have a larger than normal message size to accommodate data
+table SpectraDetectorMapping {
+    spec : [int];
+    det : [int];
+    n_spectra : int;
+}
+
+root_type SpectraDetectorMapping;


### PR DESCRIPTION
These are the current ISIS schema.

Several changes will be made shortly:
- single message per frame/pulse for neutron events
- sample environment data will move to separate schema, compatible with EPICS to Kafka forwarder
- reliance on messages being in order will be removed (`end_of` fields will be removed)
- when we can use KIP-79 some timestamps will move to Kafka message header and run info won't need  the offset in other streams for start of run.
- hopefully `NEvents` will rename to `NeutronEvents`, `SEEvent` to `SampleEnvironmentEvent` and so on.