### PR TITLE
Schema for information required by Mantid's Kafka live listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ ID (hex)      Flatbuffer schema file name
 0xrit0        rit0_psi_sinq_schema.fbs  Neutron event data according the RITA2
 0xev42        ev42_events.fbs           Multi-institution neutron event data
 0xis84        is84_isis_events.fbs      ISIS specific addition to event messages
+0xba57        ba57_run_info.fbs         Run start/stop information for Mantid
+0xdf12        df12_det_spec_map.fbs     Detector-spectrum map for Mantid
 ```
 
 ## Useful information:

--- a/schemas/ba57_run_info.fbs
+++ b/schemas/ba57_run_info.fbs
@@ -1,0 +1,23 @@
+// Run start/stop information for Mantid
+
+file_identifier "ba57";
+
+table RunStart {
+    start_time : ulong; // nanoseconds since Unix epoch (1 Jan 1970)
+    run_number : int;   // ID for the run
+    inst_name : string; // Name of the instrument
+    n_periods : int;    // Number of periods (ISIS only)
+}
+
+table RunStop {
+    stop_time : ulong;  // nanoseconds since Unix epoch (1 Jan 1970)
+}
+
+union InfoTypes { RunStart, RunStop }
+
+table RunInfo {
+    info_type : InfoTypes;
+}
+
+root_type RunInfo;
+

--- a/schemas/ba57_run_info.fbs
+++ b/schemas/ba57_run_info.fbs
@@ -3,10 +3,10 @@
 file_identifier "ba57";
 
 table RunStart {
-    start_time : ulong; // nanoseconds since Unix epoch (1 Jan 1970)
-    run_number : int;   // ID for the run
-    inst_name : string; // Name of the instrument
-    n_periods : int;    // Number of periods (ISIS only)
+    start_time : ulong;       // nanoseconds since Unix epoch (1 Jan 1970)
+    run_number : int;         // ID for the run
+    instrument_name : string; // Name of the instrument
+    n_periods : int;          // Number of periods (ISIS only)
 }
 
 table RunStop {
@@ -20,4 +20,3 @@ table RunInfo {
 }
 
 root_type RunInfo;
-

--- a/schemas/df12_det_spec_map.fbs
+++ b/schemas/df12_det_spec_map.fbs
@@ -1,0 +1,13 @@
+// Detector-spectrum mapping for use by Mantid
+// Topic may require larger than 1 MB default size limit for some instruments
+
+file_identifier "df12";
+
+table SpectraDetectorMapping {
+    spectrum : [int];    // spectrum number to map each detector_id to
+    detector_id : [int]; // list of unique detector IDs
+    n_spectra : int;     // total number of spectra
+}
+
+root_type SpectraDetectorMapping;
+


### PR DESCRIPTION
Mantid requires a detector-spectrum map and run start and stop times. Added schema for these. Eventually this information may come from the control system or configuration service.


- [x] If there are new schema in this PR I have added them to the list in README.md

