### PR TITLE
Added ns10 schema for NICOS Cache Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ so that we can easily avoid id collisions.
 ## Schema ids
 
 ```
+<<<<<<< HEAD
 ID            Flatbuffer schema file name
 
 f140        f140_general.fbs          Can encode an arbitrary EPICS PV
@@ -65,6 +66,7 @@ ai34        ai34_det_counts.fbs       Counts on each detector pixel from a singl
 ifdq        ifdq_ifcdaq_data.fbs      **Under development**
 NDAr        NDAr_NDArray_schema.fbs   **Under development**
 mo01        mo01_nmx.fbs              **Under development**
+ns10        ns10_cache_entry.fbs      Nicos cache entry
 ```
 
 ## Useful information:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ so that we can easily avoid id collisions.
 ## Schema ids
 
 ```
-<<<<<<< HEAD
 ID            Flatbuffer schema file name
 
 f140        f140_general.fbs          Can encode an arbitrary EPICS PV

--- a/schemas/ns10_cache_entry.fbs
+++ b/schemas/ns10_cache_entry.fbs
@@ -2,11 +2,12 @@
 file_identifier "ns10";
 
 /// pylint: skip-file
-table CacheEntryFB {
+table CacheEntry {
+        key:string;            // key for this entry
         time:double;           // time when this entry was set
         ttl:double;            // time to live
         expired:bool = false;  // is this entry already expired (manually or using ttl)
         value:string;          // value for the key
 }
 
-root_type CacheEntryFB;
+root_type CacheEntry;

--- a/schemas/ns10_cache_entry.fbs
+++ b/schemas/ns10_cache_entry.fbs
@@ -1,8 +1,10 @@
 
 file_identifier "ns10";
 
+
+/// pylint: skip-file
 table CacheEntryFB {
-	time:double;
+        time:double;
 	ttl:double;
 	expired:bool = false;
 	value:string;

--- a/schemas/ns10_cache_entry.fbs
+++ b/schemas/ns10_cache_entry.fbs
@@ -1,13 +1,12 @@
 
 file_identifier "ns10";
 
-
 /// pylint: skip-file
 table CacheEntryFB {
-        time:double;
-	ttl:double;
-	expired:bool = false;
-	value:string;
+        time:double;           // time when this entry was set
+        ttl:double;            // time to live
+        expired:bool = false;  // is this entry already expired (manually or using ttl)
+        value:string;          // value for the key
 }
 
 root_type CacheEntryFB;

--- a/schemas/ns10_cache_entry.fbs
+++ b/schemas/ns10_cache_entry.fbs
@@ -3,11 +3,13 @@ file_identifier "ns10";
 
 /// pylint: skip-file
 table CacheEntry {
-        key:string;            // key for this entry
-        time:double;           // time when this entry was set
-        ttl:double;            // time to live
-        expired:bool = false;  // is this entry already expired (manually or using ttl)
-        value:string;          // value for the key
+        key:string;            // key for this entry (usually nicos/device/parameter)
+        time:double;           // time (in seconds after epoch) when this entry was set
+        ttl:double;            // time to live (in seconds after time field of this entry)
+        expired:bool = false;  // already expired (manually or using ttl), supersedes ttl
+        // Value for the key.
+        // The value can be numerical types, strings, list, tuple, dictionaries, sets 
+        value:string;
 }
 
 root_type CacheEntry;

--- a/schemas/ns10_cache_entry.fbs
+++ b/schemas/ns10_cache_entry.fbs
@@ -1,0 +1,11 @@
+
+file_identifier "ns10";
+
+table CacheEntryFB {
+	time:double;
+	ttl:double;
+	expired:bool = false;
+	value:string;
+}
+
+root_type CacheEntryFB;


### PR DESCRIPTION
NICOS cache can now be stored in Kafka topics and serialized by flatbuffers using the schema added with this pull request.

