### PR TITLE
Status and component id

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ ai33        ai33_det_count_imgs.fbs   Accumulated counts of detector events
 ifdq        ifdq_ifcdaq_data.fbs      **Under development**
 NDAr        NDAr_NDArray_schema.fbs   **Under development**
 mo01        mo01_nmx.fbs              **Under development**
+cid0        cid0_component_id.fbs     **Under development**  Identify components in system
+stat        stat_status.fbs           **Under development**  Container for JSON status messages
 ```
 
 ## Useful information:

--- a/schemas/cid0_component_id.fbs
+++ b/schemas/cid0_component_id.fbs
@@ -1,0 +1,64 @@
+// ATTENTION
+//
+// This schema is still under development and may still break in the future.
+// Backwards compatibility is so far not guaranteed.
+// dominik.werder@gmail.com
+
+
+// Intended to be included in other schemas.
+// For example, status updates use it to indicate the origin of the status.
+
+// The purpose is to uniquely identify a running component in a meaningful way.
+// Each component may have their own internal hierarchy which can be
+// represented by extending the union 'ComponentType'.
+
+// For example, the epics forwarder code in NICOS wants to monitor status
+// updates from the forwarder.
+
+file_identifier "cid0";
+
+enum KafkaToNexusSubType : ubyte {
+  MASTER,
+  STREAM_MASTER,
+  STREAMER,
+}
+
+table KafkaToNexus {
+  subtype: KafkaToNexusSubType;
+}
+
+enum ForwardEpicsToKafkaSubType : ubyte {
+  MAIN,
+  EPICS_CLIENT,
+  CONVERSION_WORKER,
+}
+
+table ForwardEpicsToKafka {
+  subtype: ForwardEpicsToKafkaSubType;
+}
+
+union ComponentType {
+  KafkaToNexus,
+  ForwardEpicsToKafka,
+}
+
+table ComponentID {
+  // I expect that all machines get a globally unique hostname.
+  // Therefore, it may not be necessary to provide the IP address.
+  // Hostname will hopefully be the main way to identify a machine.
+  hostname: string;
+
+  // Just in case that 'hostname' is not available, we could identify the host
+  // via IP.  This is either 4 byte for IPv4 or 16 byte for IPv6
+  ip: [byte];
+
+  // Is there some device which does not talk IP?  Do we want MAC address?
+
+  // Examples: 'kafka-to-nexus', 'NICOS', ...
+  type: ComponentType;
+
+  // Process id makes sense to have for monitoring
+  process_id: int;
+}
+
+root_type ComponentID;

--- a/schemas/stat_status.fbs
+++ b/schemas/stat_status.fbs
@@ -1,0 +1,29 @@
+// ATTENTION
+//
+// This schema is still under development and may still break in the future.
+// Backwards compatibility is so far not guaranteed.
+// dominik.werder@gmail.com
+
+
+// Status updates from components in the system.  The actual status information
+// is provided as json, but it is useful to have a top-level flatbuffer for
+// more efficient filtering without having to parse the full json, and also to
+// statically avoid name collisions.
+
+include "cid0_component_id.fbs";
+
+file_identifier "stat";
+
+table Status {
+	// Origin of this status update. Defined in schema 'cid0'.
+	component_id: ComponentID;
+
+	// For simplicity, let's use nanoseconds since unix epoch as e.g. the event
+	// data does as well.
+	timestamp: ulong;
+
+	// The actual status data as json
+	json: string;
+}
+
+root_type Status;


### PR DESCRIPTION
New schema `cid0` to identify a component in the streaming system.

New schema `stat` to wrap json status messages together with timestamp and component id.

Following the changed workflow, both schemas are marked as under development.