### PR TITLE
Add schema for detection counts from a single pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ ev42        ev42_events.fbs           Multi-institution neutron event data
 is84        is84_isis_events.fbs      ISIS specific addition to event messages
 ba57        ba57_run_info.fbs         Run start/stop information for Mantid
 df12        df12_det_spec_map.fbs     Detector-spectrum map for Mantid
-ai33        ai33_det_count_imgs.fbs   Accumulated counts of detector events
+ai33        ai33_det_count_imgs.fbs   Accumulated counts of detection events
+ai34        ai34_det_counts.fbs       Counts on each detector pixel from a single pulse
 ifdq        ifdq_ifcdaq_data.fbs      **Under development**
 NDAr        NDAr_NDArray_schema.fbs   **Under development**
 mo01        mo01_nmx.fbs              **Under development**

--- a/schemas/ai34_det_counts.fbs
+++ b/schemas/ai34_det_counts.fbs
@@ -1,0 +1,11 @@
+// Schema for PulseImage, storing detector counts for eventmessage visualisation
+
+file_identifier "ai34";
+
+// NB, this is a sparse representation, 0 counts and their corresponding detector id are not included
+table PulseImage {
+    pulse_time : ulong;       // Time of source pulse, nanoseconds since Unix epoch (1 Jan 1970)
+    detector_id : [uint];     // Recorded detector ids. Corresponds directly by index with detection_count
+    detection_count : [uint]; // Total detection counts on each pixel from this pulse. Corresponds directly by index with detector_id
+}
+root_type PulseImage;


### PR DESCRIPTION
Added a schema which is already in use by this stream processor app: https://github.com/ScreamingUdder/detection-count-stream-processor
Contains the counts on each detector pixel from a single pulse, to use for simple visualisations.

- [x] If there are new schema in this PR I have added them to the list in README.md

