### PR TITLE
Add run number to run stop message

### DIFF
--- a/schemas/ba57_run_info.fbs
+++ b/schemas/ba57_run_info.fbs
@@ -11,6 +11,7 @@ table RunStart {
 
 table RunStop {
     stop_time : ulong;  // nanoseconds since Unix epoch (1 Jan 1970)
+    run_number : int;   // ID for the run
 }
 
 union InfoTypes { RunStart, RunStop }


### PR DESCRIPTION
- [x] If there are new schema in this PR I have added them to the list in README.md

This adds the run number to the run stop message to allow a consumer to check it corresponds to the expected run start message. This is a non-breaking change to the schema so the schema ID is unchanged.

