### PR TITLE
ns11: Schema for typed NICOS cache entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ senv        senv_data.fbs             **Under development**
 NDAr        NDAr_NDArray_schema.fbs   **Under development**
 mo01        mo01_nmx.fbs              **Under development**
 ns10        ns10_cache_entry.fbs      Nicos cache entry
+ns11        ns11_typed_cache_entry.fbs Nicos cache entry with typed data
 hs00        hs00_event_histogram.fbs  Event histogram stored in n dim array
 ```
 

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -40,8 +40,8 @@ table Array {
 table CacheEntry {
         key: string;            // key for this entry (usually nicos/device/parameter)
         time: double;           // time (in seconds after epoch) when this entry was set
-        ttl: double;            // time to live (in seconds after time field of this entry)
-        expired: bool = false;  // already expired (manually or using ttl), supersedes ttl
+        ttl: double;            // time to live (in seconds after time field of this entry). NOT TO BE USED OUTSIDE OF NICOS!
+        expired: bool = false;  // already expired (manually or using ttl), supersedes ttl. NOT TO BE USED OUTSIDE OF NICOS!
         value: Value;
 }
 

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -18,18 +18,6 @@ enum ArrayType : byte {
     SetType
 }   
 
-table ArrayByte   { value: [ byte];   array_type: ArrayType; }
-table ArrayUByte  { value: [ubyte];   array_type: ArrayType; }
-table ArrayShort  { value: [ short];  array_type: ArrayType; }
-table ArrayUShort { value: [ushort];  array_type: ArrayType; }
-table ArrayInt    { value: [ int];    array_type: ArrayType; }
-table ArrayUInt   { value: [uint];    array_type: ArrayType; }
-table ArrayLong   { value: [ long];   array_type: ArrayType; }
-table ArrayULong  { value: [ulong];   array_type: ArrayType; }
-table ArrayFloat  { value: [ float];  array_type: ArrayType; }
-table ArrayDouble { value: [ double]; array_type: ArrayType; }
-table ArrayString { value: [ string]; array_type: ArrayType; }
-
 union Value {
 	Byte,
 	Short,
@@ -43,17 +31,7 @@ union Value {
 	Double,
 	String,
 	Dict,
-	ArrayByte,
-	ArrayShort,
-	ArrayInt,
-	ArrayLong,
-	ArrayUByte,
-	ArrayUShort,
-	ArrayUInt,
-	ArrayULong,
-	ArrayFloat,
-	ArrayDouble,
-	ArrayString,
+        Array
 }
 
 table DictMapping {
@@ -62,6 +40,13 @@ table DictMapping {
 }
 
 table Dict { value: [DictMapping]; }
+
+table ArrayElement { v: Value; }
+
+table Array { 
+        value: [ArrayElement]; 
+        array_type: ArrayType; 
+}
 
 /// pylint: skip-file
 table CacheEntry {

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -1,0 +1,81 @@
+file_identifier "ns11";
+
+table Byte   { value:  byte;   }
+table UByte  { value: ubyte;   }
+table Short  { value:  short;  }
+table UShort { value: ushort;  }
+table Int    { value:  int;    }
+table UInt   { value: uint;    }
+table Long   { value:  long;   }
+table ULong  { value: ulong;   }
+table Float  { value:  float;  }
+table Double { value:  double; }
+table String { value:  string; }
+
+table ListType {}
+table TupleType {}
+table SetType {}
+
+union ArrayType {
+    ListType,
+    TupleType,
+    SetType
+}   
+
+table ArrayByte   { value: [ byte];   type: ArrayType; }
+table ArrayUByte  { value: [ubyte];   type: ArrayType; }
+table ArrayShort  { value: [ short];  type: ArrayType; }
+table ArrayUShort { value: [ushort];  type: ArrayType; }
+table ArrayInt    { value: [ int];    type: ArrayType; }
+table ArrayUInt   { value: [uint];    type: ArrayType; }
+table ArrayLong   { value: [ long];   type: ArrayType; }
+table ArrayULong  { value: [ulong];   type: ArrayType; }
+table ArrayFloat  { value: [ float];  type: ArrayType; }
+table ArrayDouble { value: [ double]; type: ArrayType; }
+table ArrayString { value: [ string]; type: ArrayType; }
+
+union Value {
+	Byte,
+	Short,
+	Int,
+	Long,
+	UByte,
+	UShort,
+	UInt,
+	ULong,
+	Float,
+	Double,
+	String,
+	Dict,
+	ArrayByte,
+	ArrayShort,
+	ArrayInt,
+	ArrayLong,
+	ArrayUByte,
+	ArrayUShort,
+	ArrayUInt,
+	ArrayULong,
+	ArrayFloat,
+	ArrayDouble,
+	ArrayString,
+	ArrayDict,
+}
+
+table DictMapping {
+        k: Value;
+        v: Value;
+}
+
+table Dict { value: [DictMapping]; }
+table ArrayDict { value: [Dict]; }
+
+/// pylint: skip-file
+table CacheEntry {
+        key: string;            // key for this entry (usually nicos/device/parameter)
+        time: double;           // time (in seconds after epoch) when this entry was set
+        ttl: double;            // time to live (in seconds after time field of this entry)
+        expired: bool = false;  // already expired (manually or using ttl), supersedes ttl
+        value: Value;
+}
+
+root_type CacheEntry;

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -1,14 +1,6 @@
 file_identifier "ns11";
 
-table Byte   { value:  byte;   }
-table UByte  { value: ubyte;   }
-table Short  { value:  short;  }
-table UShort { value: ushort;  }
-table Int    { value:  int;    }
-table UInt   { value: uint;    }
 table Long   { value:  long;   }
-table ULong  { value: ulong;   }
-table Float  { value:  float;  }
 table Double { value:  double; }
 table String { value:  string; }
 
@@ -19,15 +11,7 @@ enum ArrayType : byte {
 }   
 
 union Value {
-	Byte,
-	Short,
-	Int,
 	Long,
-	UByte,
-	UShort,
-	UInt,
-	ULong,
-	Float,
 	Double,
 	String,
 	Dict,

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -12,12 +12,8 @@ table Float  { value:  float;  }
 table Double { value:  double; }
 table String { value:  string; }
 
-table ListType {}
-table TupleType {}
-table SetType {}
-
-union ArrayType {
-    ListType,
+enum ArrayType : byte {
+    ListType = 0,
     TupleType,
     SetType
 }   

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -18,17 +18,17 @@ enum ArrayType : byte {
     SetType
 }   
 
-table ArrayByte   { value: [ byte];   type: ArrayType; }
-table ArrayUByte  { value: [ubyte];   type: ArrayType; }
-table ArrayShort  { value: [ short];  type: ArrayType; }
-table ArrayUShort { value: [ushort];  type: ArrayType; }
-table ArrayInt    { value: [ int];    type: ArrayType; }
-table ArrayUInt   { value: [uint];    type: ArrayType; }
-table ArrayLong   { value: [ long];   type: ArrayType; }
-table ArrayULong  { value: [ulong];   type: ArrayType; }
-table ArrayFloat  { value: [ float];  type: ArrayType; }
-table ArrayDouble { value: [ double]; type: ArrayType; }
-table ArrayString { value: [ string]; type: ArrayType; }
+table ArrayByte   { value: [ byte];   array_type: ArrayType; }
+table ArrayUByte  { value: [ubyte];   array_type: ArrayType; }
+table ArrayShort  { value: [ short];  array_type: ArrayType; }
+table ArrayUShort { value: [ushort];  array_type: ArrayType; }
+table ArrayInt    { value: [ int];    array_type: ArrayType; }
+table ArrayUInt   { value: [uint];    array_type: ArrayType; }
+table ArrayLong   { value: [ long];   array_type: ArrayType; }
+table ArrayULong  { value: [ulong];   array_type: ArrayType; }
+table ArrayFloat  { value: [ float];  array_type: ArrayType; }
+table ArrayDouble { value: [ double]; array_type: ArrayType; }
+table ArrayString { value: [ string]; array_type: ArrayType; }
 
 union Value {
 	Byte,
@@ -54,7 +54,6 @@ union Value {
 	ArrayFloat,
 	ArrayDouble,
 	ArrayString,
-	ArrayDict,
 }
 
 table DictMapping {
@@ -63,7 +62,6 @@ table DictMapping {
 }
 
 table Dict { value: [DictMapping]; }
-table ArrayDict { value: [Dict]; }
 
 /// pylint: skip-file
 table CacheEntry {

--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -1,8 +1,10 @@
 file_identifier "ns11";
 
+table Bool   { value:  bool;   }
 table Long   { value:  long;   }
 table Double { value:  double; }
 table String { value:  string; }
+table Object { value:  string; } // Python object represented as string
 
 enum ArrayType : byte {
     ListType = 0,
@@ -11,11 +13,13 @@ enum ArrayType : byte {
 }   
 
 union Value {
-	Long,
-	Double,
-	String,
-	Dict,
-        Array
+    Object,
+    Bool,
+    Long,
+    Double,
+    String,
+    Dict,
+    Array
 }
 
 table DictMapping {


### PR DESCRIPTION
- [x] If there are new schema in this PR I have added them to the list in README.md

Schema for writing cache entries from NICOS with properly typed values. Following types are supported:

- Numerical/String types
- Dict
- Tuple
- List
- Set

