### PR TITLE
Add float to hs00 schema

### DIFF
--- a/schemas/hs00_event_histogram.fbs
+++ b/schemas/hs00_event_histogram.fbs
@@ -4,12 +4,14 @@ file_identifier "hs00";
 table ArrayUInt   { value: [uint];    }
 table ArrayULong  { value: [ulong];   }
 table ArrayDouble { value: [double];  }
+table ArrayFloat  { value: [float];   }
 
 // Union of allowed data types for the arrays
 union Array {
     ArrayUInt,
     ArrayULong,
-    ArrayDouble
+    ArrayDouble,
+    ArrayFloat,
 }
 
 // Meta information for one dimension


### PR DESCRIPTION
### Description of Work

Adds float32 data type to histogram schema and keeps the backward compatibility


