### PR TITLE
Json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ns11        ns11_typed_cache_entry.fbs        Nicos cache entry with typed data
 hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
-JSON        json_json.fbs                     Carries a JSON payload
+json        json_json.fbs                     Carries a JSON payload
 ```
 
 ## Useful information:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ NDAr        NDAr_NDArray_schema.fbs   **Under development**
 mo01        mo01_nmx.fbs              **Under development**
 ns10        ns10_cache_entry.fbs      Nicos cache entry
 hs00        hs00_event_histogram.fbs  Event histogram stored in n dim array
+JSON        json_json.fbs             Carries a JSON payload
 ```
 
 ## Useful information:

--- a/schemas/json_json.fbs
+++ b/schemas/json_json.fbs
@@ -1,6 +1,8 @@
 file_identifier "json";
 
-// A simple schema to carry a JSON payload
+// A simple schema to carry a JSON payload.
+// Use when set flatbuffer structures are too inflexible,
+// for example for the File Writer command defining NeXus file structure
 
 table JsonData {
 	json: string; // must be valid json with utf8 encoding

--- a/schemas/json_json.fbs
+++ b/schemas/json_json.fbs
@@ -1,0 +1,9 @@
+file_identifier "json";
+
+// A simple schema to carry a JSON payload
+
+table JsonData {
+	json: string; // must be valid json with utf8 encoding
+}
+
+root_type JsonData;


### PR DESCRIPTION
### Description of Work

Add a simple schema to carry a JSON payload. Replacing our current "raw JSON" messages with this would mean all messages on Kafka are flatbuffer-serialised and have a file identifier.

Associated JIRA ticket: https://jira.esss.lu.se/browse/DM-1048

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


