### PR TITLE
Fix PR build failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,11 +72,17 @@ def get_pipeline(image_key) {
   }  // return
 }  // def
 
-node {
+node('docker') {
   // Checkout on docker node,
   // we need to be able to copy the code into each container
-  node('docker') {
-    checkout scm
+  dir("${project}") {
+    stage('Checkout') {
+      try {
+          scm_vars = checkout scm
+      } catch (e) {
+          failure_function(e, 'Checkout failed')
+      }
+    }
   }
 
   def builders = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ images = [
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
 
-def docker_copy_code(container_name) {
+def docker_copy_code(image_key, container_name) {
     def custom_sh = images[image_key]['sh']
     sh "docker cp ${project} ${container_name}:/home/jenkins/${project}"
     sh """docker exec --user root ${container_name} ${custom_sh} -c \"
@@ -23,7 +23,7 @@ def docker_copy_code(container_name) {
                         \""""
 }
 
-def docker_dependencies(container_name) {
+def docker_dependencies(image_key, container_name) {
   def conan_remote = "ess-dmsc-local"
   def custom_sh = images[image_key]['sh']
   sh """docker exec ${container_name} ${custom_sh} -c \"
@@ -65,9 +65,9 @@ def get_pipeline(image_key) {
           --env local_conan_server=${env.local_conan_server} \
         ")
 
-        docker_copy_code(container_name)
-        docker_dependencies(container_name)
-        docker_test(container_name)
+        docker_copy_code(image_key, container_name)
+        docker_dependencies(image_key, container_name)
+        docker_test(image_key, container_name)
 
       } catch(e) {
         failure_function(e, 'Build failed')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ images = [
 
 base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
 
-def docker_copy_code(image_key) {
+def docker_copy_code(image_key, container_name) {
     def custom_sh = images[image_key]['sh']
     sh "docker cp ${project} ${container_name(image_key)}:/home/jenkins/${project}"
     sh """docker exec --user root ${container_name(image_key)} ${custom_sh} -c \"
@@ -23,7 +23,7 @@ def docker_copy_code(image_key) {
                         \""""
 }
 
-def docker_dependencies(image_key) {
+def docker_dependencies(image_key, container_name) {
   def conan_remote = "ess-dmsc-local"
   def custom_sh = images[image_key]['sh']
   sh """docker exec ${container_name} ${custom_sh} -c \"
@@ -39,7 +39,7 @@ def docker_dependencies(image_key) {
   \""""
 }
 
-def docker_test(image_key) {
+def docker_test(image_key, container_name) {
   def custom_sh = images[image_key]['sh']
   sh """docker exec ${container_name} ${custom_sh} -c \"
     source build/activate_run.sh
@@ -65,9 +65,9 @@ def get_pipeline(image_key) {
           --env local_conan_server=${env.local_conan_server} \
         ")
 
-        docker_copy_code(image_key)
-        docker_dependencies(image_key)
-        docker_test(image_key)
+        docker_copy_code(image_key, container_name)
+        docker_dependencies(image_key, container_name)
+        docker_test(image_key, container_name)
 
       } catch(e) {
         failure_function(e, 'Build failed')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def failure_function(exception_obj, failureMessage) {
 
 images = [
   'centos7': [
-    'name': 'essdmscdm/centos7-build-node:3.0.0',
+    'name': 'essdmscdm/centos7-build-node:3.1.0',
     'sh': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e'
   ],
 ]


### PR DESCRIPTION
### Description of Work

Copies code into each container rather than checking out from github each time. Saves some bandwidth and solves the PR build problem by not requiring a branch name.

I updated the version of flatbuffers used to 1.9.0 and the version of the centos docker image to 3.1.0.

### Issue

Closes #31

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*


