### PR TITLE
Replace log data schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ ns11        ns11_typed_cache_entry.fbs        Nicos cache entry with typed data
 hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
+f144        f144_logdata.fbs                  For log data, for example forwarded EPICS PV updates
 ```
 
 ## Useful information:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ so that we can easily avoid id collisions.
 ```
 ID            Flatbuffer schema file name
 
-f140        f140_general.fbs                  Can encode an arbitrary EPICS PV [OBSOLETE]
-f141        f141_ntarraydouble.fbs            A simple array of double, testing file writing [OBSOLETE]
-f143        f143_structure.fbs                Arbitrary nested data [OBSOLETE]
+f140        f140_general.fbs                  [OBSOLETE] Can encode an arbitrary EPICS PV
+f141        f141_ntarraydouble.fbs            [OBSOLETE] A simple array of double, testing file writing
+f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
 rit0        rit0_psi_sinq_schema.fbs          Neutron event data according the RITA2
 ev42        ev42_events.fbs                   Multi-institution neutron event data
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
@@ -73,7 +73,7 @@ ns11        ns11_typed_cache_entry.fbs        Nicos cache entry with typed data
 hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
-f142        f142_logdata.fbs                  For log data, for example forwarded EPICS PV updates [OBSOLETE]
+f142        f142_logdata.fbs                  [OBSOLETE] For log data, for example forwarded EPICS PV update
 f144        f144_logdata.fbs                  For log data, for example forwarded EPICS PV updates
 json        json_json.fbs                     Carries a JSON payload
 ```

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ so that we can easily avoid id collisions.
 ```
 ID            Flatbuffer schema file name
 
-f140        f140_general.fbs                  Can encode an arbitrary EPICS PV
-f141        f141_ntarraydouble.fbs            A simple array of double, testing file writing
-f143        f143_structure.fbs                Arbitrary nested data
+f140        f140_general.fbs                  Can encode an arbitrary EPICS PV [OBSOLETE]
+f141        f141_ntarraydouble.fbs            A simple array of double, testing file writing [OBSOLETE]
+f143        f143_structure.fbs                Arbitrary nested data [OBSOLETE]
 rit0        rit0_psi_sinq_schema.fbs          Neutron event data according the RITA2
 ev42        ev42_events.fbs                   Multi-institution neutron event data
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
@@ -73,6 +73,7 @@ ns11        ns11_typed_cache_entry.fbs        Nicos cache entry with typed data
 hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
+f142        f142_logdata.fbs                  For log data, for example forwarded EPICS PV updates [OBSOLETE]
 f144        f144_logdata.fbs                  For log data, for example forwarded EPICS PV updates
 json        json_json.fbs                     Carries a JSON payload
 ```

--- a/schemas/ep00_epics_connection_info.fbs
+++ b/schemas/ep00_epics_connection_info.fbs
@@ -16,6 +16,8 @@ table EpicsConnectionInfo {
   type: EventType;
   // The channel name, called `source_name` to stay in sync with `f142`
   source_name: string;
+  // Identifies the client which has observed the event
+  service_id: string;
 }
 
 root_type EpicsConnectionInfo;

--- a/schemas/ep00_epics_connection_info.fbs
+++ b/schemas/ep00_epics_connection_info.fbs
@@ -16,8 +16,6 @@ table EpicsConnectionInfo {
   type: EventType;
   // The channel name, called `source_name` to stay in sync with `f142`
   source_name: string;
-  // Identifies the client which has observed the event
-  service_id: string;
 }
 
 root_type EpicsConnectionInfo;

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -1,0 +1,65 @@
+file_identifier "f144";
+
+table Byte   { value:  byte;   }
+table UByte  { value: ubyte;   }
+table Short  { value:  short;  }
+table UShort { value: ushort;  }
+table Int    { value:  int;    }
+table UInt   { value: uint;    }
+table Long   { value:  long;   }
+table ULong  { value: ulong;   }
+table Float  { value:  float;  }
+table Double { value:  double; }
+table String { value: string; }
+
+table ArrayByte   { value: [ byte];   }
+table ArrayUByte  { value: [ubyte];   }
+table ArrayShort  { value: [ short];  }
+table ArrayUShort { value: [ushort];  }
+table ArrayInt    { value: [ int];    }
+table ArrayUInt   { value: [uint];    }
+table ArrayLong   { value: [ long];   }
+table ArrayULong  { value: [ulong];   }
+table ArrayFloat  { value: [ float];  }
+table ArrayDouble { value: [ double]; }
+table ArrayString { value: [string]; }
+
+union Value {
+	Byte,
+	UByte,
+	Short,
+	UShort,
+	Int,
+	UInt,
+	Long,
+	ULong,
+	Float,
+	Double,
+	ArrayByte,
+	ArrayUByte,
+	ArrayShort,
+	ArrayUShort,
+	ArrayInt,
+	ArrayUInt,
+	ArrayLong,
+	ArrayULong,
+	ArrayFloat,
+	ArrayDouble,
+
+	// NOTE
+	// FlatBuffers does not specify encoding, but we require it to be utf8.
+	String,
+	ArrayString
+}
+
+// Typical producers and consumers:
+// Produced by EPICS forwarder from EPICS PV
+// Consumed by NeXus file writer -> NXLog
+// Consumed by Mantid -> Sample environment log
+table LogData {
+	source_name: string; // identify source on multiplexed topics, e.g. PV name if from EPICS
+	value: Value;        // may be scalar or array
+	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
+}
+
+root_type LogData;

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -1,3 +1,11 @@
+// Log data, for example "slow" sample environment measurements
+//
+// Typical producers and consumers:
+// Produced by EPICS forwarder from EPICS PV
+// Produced by NeXus-Streamer from NXlogs
+// Consumed by NeXus file writer -> NXLog
+// Consumed by Mantid -> Workspace log
+
 file_identifier "f144";
 
 table Byte   { value:  byte;   }
@@ -52,14 +60,37 @@ union Value {
 	ArrayString
 }
 
-// Typical producers and consumers:
-// Produced by EPICS forwarder from EPICS PV
-// Consumed by NeXus file writer -> NXLog
-// Consumed by Mantid -> Sample environment log
+enum AlarmStatus: ushort {
+    NO_ALARM,
+    READ,
+    WRITE,
+    HIHI,
+    HIGH,
+    LOLO,
+    LOW,
+    STATE,
+    COS,
+    COMM,
+    TIMED,
+    HWLIMIT,
+    CALC,
+    SCAN,
+    LINK,
+    SOFT,
+    BAD_SUB,
+    UDF,
+    DISABLE,
+    SIMM,
+    READ_ACCESS,
+    WRITE_ACCESS,
+    NO_CHANGE
+}
+
 table LogData {
-	source_name: string; // identify source on multiplexed topics, e.g. PV name if from EPICS
-	value: Value;        // may be scalar or array
-	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
+	source_name: string;              // identify source on multiplexed topics, e.g. PV name if from EPICS
+	value: Value;                     // may be scalar or array
+	timestamp: ulong;                 // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
+	status: AlarmStatus = NO_CHANGE;  // details of EPICS alarm, default being no change: file writer only records changes
 }
 
 root_type LogData;


### PR DESCRIPTION
### Description of Work

Created a replacement for the f142 schema by removing the obsolete internal forwarder information field and adding the EPICS alarm status for DM-872. Breaking change so requires new schema id.

The default of `NO_CHANGE` for the alarm status indicates that the file writer should not record the alarm status. The producer (forwarder) does not need to populate the field in this case and it uses no space on the wire.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


