### PR TITLE
Update run info schema to include instrument geometry for Mantid

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ f143        f143_structure.fbs                Arbitrary nested data
 rit0        rit0_psi_sinq_schema.fbs          Neutron event data according the RITA2
 ev42        ev42_events.fbs                   Multi-institution neutron event data
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
-ba57        ba57_run_info.fbs                 Run start/stop information for Mantid
+ba57        ba57_run_info.fbs                 Run start/stop information for Mantid [superceded by y2gw]
+y2gw        y2gw_run_info.fbs                 Run start/stop information for Mantid
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid
 ai33        ai33_det_count_imgs.fbs           Accumulated counts of detection events
 ai34        ai34_det_counts.fbs               Counts on each detector pixel from a single pulse

--- a/schemas/y2gw_run_info.fbs
+++ b/schemas/y2gw_run_info.fbs
@@ -1,0 +1,26 @@
+// Run start/stop messages used by Mantid
+// Not to be confused with file writer start/stop messages
+
+file_identifier "y2gw";
+
+table RunStart {
+    start_time : ulong;       // nanoseconds since Unix epoch (1 Jan 1970)
+    run_id : string;          // ID for the run
+    instrument_name : string; // Name of the instrument
+    n_periods : int;          // Number of periods (optional, for ISIS only)
+    nexus_structure : string; // JSON description of NeXus file, used as source of instrument geometry information
+                              // See https://github.com/ess-dmsc/kafka-to-nexus/ for documentation of nexus_structure
+}
+
+table RunStop {
+    stop_time : ulong;  // nanoseconds since Unix epoch (1 Jan 1970)
+    run_id : string;    // ID for the run, must match corresponding RunStart
+}
+
+union InfoTypes { RunStart, RunStop }
+
+table RunInfo {
+    info_type : InfoTypes;
+}
+
+root_type RunInfo;

--- a/schemas/y2gw_run_info.fbs
+++ b/schemas/y2gw_run_info.fbs
@@ -1,4 +1,5 @@
-// Run start/stop messages used by Mantid
+// Run start/stop messages consumed by Mantid
+// Potential producers include NeXus-Streamer and Nicos
 // Not to be confused with file writer start/stop messages
 
 file_identifier "y2gw";


### PR DESCRIPTION
### Description of Work

Update run info schema to support publishing instrument geometry for Mantid. Breaking change to run number/id field, so requires new file identifier. The logic behind changing the `run_number: int` field to `run_id: string` is to allow Nicos could reuse something it already has to identify the run with. This field is used by Mantid as a name for the output workspace.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


