### PR TITLE
F142 epics alarms DM-872

### DIFF
--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -61,6 +61,31 @@ enum AlarmSeverity: ushort {
     INVALID,    
 }
 
+enum AlarmStatus: ushort {
+    NO_ALARM,
+    READ,
+    WRITE,
+    HIHI,
+    HIGH,
+    LOLO,
+    LOW,
+    STATE,
+    COS,
+    COMM,
+    TIMED,
+    HWLIMIT,
+    CALC,
+    SCAN,
+    LINK,
+    SOFT,
+    BAD_SUB,
+    UDF,
+    DISABLE,
+    SIMM,
+    READ_ACCESS,
+    WRITE_ACCESS
+}
+
 // Typical producers and consumers:
 // Produced by EPICS forwarder from EPICS PV
 // Consumed by NeXus file writer -> NXLog

--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -95,6 +95,8 @@ table LogData {
 	value: Value;        // may be scalar or array
 	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
 	fwdinfo: forwarder_internal;  // optional, for development and debug used by EPICS forwarder
+	AlarmSeverity: alarm_severity;
+	AlarmStatus: alarm_status;
 }
 
 root_type LogData;

--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -54,6 +54,13 @@ union Value {
 	ArrayString
 }
 
+enum AlarmSeverity: ushort {
+    NO_ALARM,
+    MINOR,
+    MAJOR,
+    INVALID,    
+}
+
 // Typical producers and consumers:
 // Produced by EPICS forwarder from EPICS PV
 // Consumed by NeXus file writer -> NXLog

--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -54,13 +54,6 @@ union Value {
 	ArrayString
 }
 
-enum AlarmSeverity: ushort {
-    NO_ALARM,
-    MINOR,
-    MAJOR,
-    INVALID,    
-}
-
 enum AlarmStatus: ushort {
     NO_ALARM,
     READ,
@@ -86,11 +79,6 @@ enum AlarmStatus: ushort {
     WRITE_ACCESS
 }
 
-struct AlarmInfo {
-	severity: AlarmSeverity;
-	status: AlarmStatus;
-}
-
 // Typical producers and consumers:
 // Produced by EPICS forwarder from EPICS PV
 // Consumed by NeXus file writer -> NXLog
@@ -100,7 +88,7 @@ table LogData {
 	value: Value;        // may be scalar or array
 	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
 	fwdinfo: forwarder_internal;  // optional, for development and debug used by EPICS forwarder
-	alarm_info: AlarmInfo; // struct holding epics alarm detail
+	status: AlarmStatus; // details of EPICS alarm
 }
 
 root_type LogData;

--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -86,6 +86,11 @@ enum AlarmStatus: ushort {
     WRITE_ACCESS
 }
 
+struct AlarmInfo {
+	severity: AlarmSeverity;
+	status: AlarmStatus;
+}
+
 // Typical producers and consumers:
 // Produced by EPICS forwarder from EPICS PV
 // Consumed by NeXus file writer -> NXLog
@@ -95,8 +100,7 @@ table LogData {
 	value: Value;        // may be scalar or array
 	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
 	fwdinfo: forwarder_internal;  // optional, for development and debug used by EPICS forwarder
-	AlarmSeverity: alarm_severity;
-	AlarmStatus: alarm_status;
+	alarm_info: AlarmInfo; // struct holding epics alarm detail
 }
 
 root_type LogData;


### PR DESCRIPTION
### Description of Work

In order to forward epics alarms I created an `AlarmInfo` struct and two new enums: `AlarmSeverity` and `AlarmStatus`. `AlarmInfo` contains fields of both enum types. Field of type `AlarmInfo` was added to `LogData`.

### Issue

DM-872

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


