### PR TITLE
Epics alarms in f142

### DIFF
--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -76,7 +76,8 @@ enum AlarmStatus: ushort {
     DISABLE,
     SIMM,
     READ_ACCESS,
-    WRITE_ACCESS
+    WRITE_ACCESS,
+    NO_CHANGE
 }
 
 // Typical producers and consumers:
@@ -88,7 +89,7 @@ table LogData {
 	value: Value;        // may be scalar or array
 	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
 	fwdinfo: forwarder_internal;  // optional, for development and debug used by EPICS forwarder
-	status: AlarmStatus; // details of EPICS alarm
+	status: AlarmStatus = NO_CHANGE; // details of EPICS alarm with default being no change
 }
 
 root_type LogData;

--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -54,6 +54,31 @@ union Value {
 	ArrayString
 }
 
+enum AlarmStatus: ushort {
+    NO_ALARM,
+    READ,
+    WRITE,
+    HIHI,
+    HIGH,
+    LOLO,
+    LOW,
+    STATE,
+    COS,
+    COMM,
+    TIMED,
+    HWLIMIT,
+    CALC,
+    SCAN,
+    LINK,
+    SOFT,
+    BAD_SUB,
+    UDF,
+    DISABLE,
+    SIMM,
+    READ_ACCESS,
+    WRITE_ACCESS
+}
+
 // Typical producers and consumers:
 // Produced by EPICS forwarder from EPICS PV
 // Consumed by NeXus file writer -> NXLog
@@ -63,6 +88,7 @@ table LogData {
 	value: Value;        // may be scalar or array
 	timestamp: ulong;    // nanoseconds past epoch (1 Jan 1970), zero reserved for invalid timestamp
 	fwdinfo: forwarder_internal;  // optional, for development and debug used by EPICS forwarder
+	status: AlarmStatus; // details of EPICS alarm
 }
 
 root_type LogData;


### PR DESCRIPTION
### Description of Work

Added an `AlarmStatus` enum field in `f142` `LogData` to forward status of Epics alarms.

### Issue

part of [DM-872](https://jira.esss.lu.se/secure/RapidBoard.jspa?rapidView=659&view=detail&selectedIssue=DM-872)

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


