### PR TITLE
Fix of problem in design of ADC debug schema.

### DIFF
--- a/schemas/dtdb_adc_pulse_debug.fbs
+++ b/schemas/dtdb_adc_pulse_debug.fbs
@@ -4,12 +4,11 @@
 file_identifier "dtdb";
 
 table AdcPulseDebug {
-  amplitude : [uint];           // Amplitude of the pulse above bkg.
-  peak_area : [uint];           // Area under the curve of the pulse.
-  background : [uint];          // Background level of pulses.
-  threshold_time : [uint];      // Nanoseconds, offset time since `pulse_time`
-                                // when the pulse passed threshold on the
-                                // rising edge
-  peak_time : [uint];           // Nanoseconds, offset time since `pulse_time`
-                                // when the pulse reaches its peak value                                
+  amplitude : [uint32];         // Amplitude of the pulse above bkg.
+  peak_area : [uint32];         // Area under the curve of the pulse.
+  background : [uint32];        // Background level of pulses.
+  threshold_time : [uint64];    // Timestamp in (ns) UNIX epoch when the pulse
+                                // passed the threshold on the rising edge
+  peak_time : [uint64];         // Timestamp in (ns) UNIX epoch when the pulse
+                                // reached its peak value
 }


### PR DESCRIPTION
### Description of Work

Turns out that having multiple relative timestamps in the buffer when there is a risk of overflowing the the type that is used to store those timestamps is a bit problematic.

### Issue

*If there is an associated issue, write 'Closes #XXX'*

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.

