### PR TITLE
Use jenkins shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,6 @@ builders = pipeline_builder.createBuilders { container ->
     
     pipeline_builder.stage("${container.key}: test") {
         container.sh """
-            docker exec ${container_name} ${custom_sh} -c \"
             source build/activate_run.sh
             cd ${project}
             jenkins/done.bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,108 +1,60 @@
+@Library('ecdc-pipeline')
+import ecdcpipeline.ContainerBuildNode
+import ecdcpipeline.PipelineBuilder
+
 project = "streaming-data-types"
 
-def failure_function(exception_obj, failureMessage) {
-    def toEmails = [[$class: 'DevelopersRecipientProvider']]
-    emailext body: '${DEFAULT_CONTENT}\n\"' + failureMessage + '\"\n\nCheck console output at $BUILD_URL to view the results.', recipientProviders: toEmails, subject: '${DEFAULT_SUBJECT}'
-    throw exception_obj
-}
-
-images = [
-  'centos7': [
-    'name': 'essdmscdm/centos7-build-node:3.1.0',
-    'sh': '/usr/bin/scl enable devtoolset-6 -- /bin/bash -e'
-  ],
+container_build_nodes = [
+  'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7')
 ]
 
-base_container_name = "${project}-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+pipeline_builder = new PipelineBuilder(this, container_build_nodes)
+pipeline_builder.activateEmailFailureNotifications()
 
-def docker_copy_code(image_key, container_name) {
-    def custom_sh = images[image_key]['sh']
-    sh "docker cp ${project} ${container_name}:/home/jenkins/${project}"
-    sh """docker exec --user root ${container_name} ${custom_sh} -c \"
-                        chown -R jenkins.jenkins /home/jenkins/${project}
-                        \""""
-}
+builders = pipeline_builder.createBuilders { container ->
 
-def docker_dependencies(image_key, container_name) {
-  def conan_remote = "ess-dmsc-local"
-  def custom_sh = images[image_key]['sh']
-  sh """docker exec ${container_name} ${custom_sh} -c \"
-    mkdir build
-    cd build
-    conan --version
-    conan remote add \
-      --insert 0 \
-      ${conan_remote} ${local_conan_server}
-    conan install \
-      --generator virtualrunenv \
-      FlatBuffers/1.9.0@ess-dmsc/stable
-  \""""
-}
-
-def docker_test(image_key, container_name) {
-  def custom_sh = images[image_key]['sh']
-  sh """docker exec ${container_name} ${custom_sh} -c \"
-    source build/activate_run.sh
-    cd ${project}
-    jenkins/done.bash
-  \""""
-}
-
-def get_pipeline(image_key) {
-  return {
-    stage("${image_key}") {
-      def container_name = "${base_container_name}-${image_key}"
-      try {
-        def image = docker.image(images[image_key]['name'])
-        def container = image.run("\
-          --name ${container_name} \
-          --tty \
-          --cpus=2 \
-          --memory=4GB \
-          --network=host \
-          --env http_proxy=${env.http_proxy} \
-          --env https_proxy=${env.https_proxy} \
-          --env local_conan_server=${env.local_conan_server} \
-        ")
-
-        docker_copy_code(image_key, container_name)
-        docker_dependencies(image_key, container_name)
-        docker_test(image_key, container_name)
-
-      } catch(e) {
-        failure_function(e, 'Build failed')
-      } finally {
-        sh "docker stop ${container_name}"
-        sh "docker rm -f ${container_name}"
-      }  // finally
+    pipeline_builder.stage("${container.key}: checkout") {
+        dir(pipeline_builder.project) {
+            scm_vars = checkout scm
+        }
+        // Copy source code to container
+        container.copyTo(pipeline_builder.project, pipeline_builder.project)
     }  // stage
-  }  // return
-}  // def
 
-node('docker') {
-  // Checkout on docker node,
-  // we need to be able to copy the code into each container
-  dir("${project}") {
-    stage('Checkout') {
-      try {
-          checkout scm
-      } catch (e) {
-          failure_function(e, 'Checkout failed')
-      }
+    pipeline_builder.stage("${container.key}: get dependencies") {
+        container.sh """
+            mkdir build
+            cd build
+            conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
+            conan install --generator virtualrunenv flatbuffers/1.10.0google/stable
+        """
+    }  // stage
+    
+    pipeline_builder.stage("${container.key}: test") {
+        container.sh """
+            docker exec ${container_name} ${custom_sh} -c \"
+            source build/activate_run.sh
+            cd ${project}
+            jenkins/done.bash
+        """
+    
     }
-  }
 
-  def builders = [:]
-  for (x in images.keySet()) {
-    def image_key = x
-    builders[image_key] = get_pipeline(image_key)
-  }
-  try {
+node {
+    cleanWs()
+
+    stage('Checkout') {
+        dir("${project}") {
+            try {
+                scm_vars = checkout scm
+            } catch (e) {
+                failure_function(e, 'Checkout failed')
+            }
+        }
+    }
+
     parallel builders
-  } catch (e) {
-    failure_function(e, 'Job failed')
-  }
 
-  // Delete workspace when build is done.
-  cleanWs()
+    // Delete workspace when build is done
+    cleanWs()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ builders = pipeline_builder.createBuilders { container ->
             mkdir build
             cd build
             conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
-            conan install --generator virtualrunenv flatbuffers/1.10.0@google/stable
+            conan install --generator virtualrunenv flatbuffers/1.11.0@google/stable
         """
     }  // stage
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ builders = pipeline_builder.createBuilders { container ->
             mkdir build
             cd build
             conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
-            conan install --generator virtualrunenv flatbuffers/1.11.0@google/stable
+            conan install --generator virtualrunenv flatbuffers/1.11.0@google/stable --build=outdated
         """
     }  // stage
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,12 @@ builders = pipeline_builder.createBuilders { container ->
     }  // stage
 }  // create builders
 
+def failure_function(exception_obj, failureMessage) {
+    def toEmails = [[$class: 'DevelopersRecipientProvider']]
+    emailext body: '${DEFAULT_CONTENT}\n\"' + failureMessage + '\"\n\nCheck console output at $BUILD_URL to view the results.', recipientProviders: toEmails, subject: '${DEFAULT_SUBJECT}'
+    throw exception_obj
+}
+
 node {
     cleanWs()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ builders = pipeline_builder.createBuilders { container ->
             mkdir build
             cd build
             conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
-            conan install --generator virtualrunenv flatbuffers/1.10.0google/stable
+            conan install --generator virtualrunenv flatbuffers/1.10.0@google/stable
         """
     }  // stage
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,8 @@ builders = pipeline_builder.createBuilders { container ->
             jenkins/done.bash
         """
     
-    }
+    }  // stage
+}  // create builders
 
 node {
     cleanWs()


### PR DESCRIPTION
### Description of Work
Update Jenkinsfile to make use of the Jenkins shared library.

Taking the opportunity to update to flatbuffers 1.11.0 which is being used by some of our codebases already. Notably it supports getting numpy arrays for vectors in generated python.

I'll update the schema conan package to depend on 1.11 once #45 is merged
