### PR TITLE
Define root type in 6s4t schema

### DIFF
--- a/schemas/6s4t_run_stop.fbs
+++ b/schemas/6s4t_run_stop.fbs
@@ -15,3 +15,5 @@ table RunStop {              //  *Mantid*    // *File Writer* // *Description*
     job_id : string;         //  Unused      //  Required     // A unique identifier for the file writing job
     service_id : string;     //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
 }
+
+root_type RunStop;


### PR DESCRIPTION
### Description of Work

Fixes missing root type in the `6s4t` schema.

