### PR TITLE
Fix mislabelled time precision in run start and stop schemas

### DIFF
--- a/schemas/6s4t_run_stop.fbs
+++ b/schemas/6s4t_run_stop.fbs
@@ -10,7 +10,7 @@
 file_identifier "6s4t";
 
 table RunStop {              //  *Mantid*    // *File Writer* // *Description*
-    stop_time : uint64;      //  Required    //  Required     // nanoseconds since Unix epoch (1 Jan 1970)
+    stop_time : uint64;      //  Required    //  Required     // milliseconds since Unix epoch (1 Jan 1970)
     run_name : string;       //  Required    //  Unused       // Name for the run, must match corresponding field in RunStart
     job_id : string;         //  Unused      //  Required     // A unique identifier for the file writing job
     service_id : string;     //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command

--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -12,8 +12,8 @@ include "df12_det_spec_map.fbs";
 file_identifier "pl72";
 
 table RunStart {                                     //  *Mantid*    // *File Writer* // *Description*
-    start_time : uint64;                             //  Required    //  Optional     // nanoseconds since Unix epoch (1 Jan 1970)
-    stop_time : uint64;                              //  Unused      //  Optional     // nanoseconds since Unix epoch (1 Jan 1970), optional, can send a RunStop instead
+    start_time : uint64;                             //  Required    //  Optional     // milliseconds since Unix epoch (1 Jan 1970)
+    stop_time : uint64;                              //  Unused      //  Optional     // milliseconds since Unix epoch (1 Jan 1970), optional, can send a RunStop instead
     run_name : string;                               //  Required    //  Unused       // Name for the run, used as workspace name by Mantid
     instrument_name : string;                        //  Required    //  Unused       // Name of the instrument, only required by Mantid
     nexus_structure : string;                        //  Optional    //  Required     // JSON description of NeXus file (See https://github.com/ess-dmsc/kafka-to-nexus/ for detail)


### PR DESCRIPTION
When I created the new run start and stop schemas I mislabelled the start and stop time as nanoseconds. They should be milliseconds to match Kafka header timestamp precision.