### PR TITLE
Add status message schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ json        json_json.fbs                     Carries a JSON payload
 tdct        tdct_timestamps.fbs               Timestamps from a device (e.g. a chopper)
 pl72        pl72_run_start.fbs                File writing, run start message for file writer and Mantid
 6s4t        6s4t_run_stop.fbs                 File writing, run stop message for file writer and Mantid
+x5f2        x5f2_status.fbs                   Status update and heartbeat message for any software
 ```
 
 ## Useful information:

--- a/schemas/x5f2_status.fbs
+++ b/schemas/x5f2_status.fbs
@@ -1,0 +1,15 @@
+// Status message
+// To act as heatbeat and status report from any software
+
+file_identifier "x5f2";
+
+table Status {
+    software_name : string;      // Name of the software publishing the status message
+    software_version : string;   // Version number of the software publishing the status message
+    system_name : string;        // System name to identify where the software is running
+    process_id : int32;          // Identify particular process in case there are multiple instances of the same software running on the same system
+    period : int32;              // Update period in seconds for status messages, so consumer knows when to expect another message
+    status_json : string;        // Status information specific to the software publishing this message, in JSON format
+}
+
+root_type Status;

--- a/schemas/x5f2_status.fbs
+++ b/schemas/x5f2_status.fbs
@@ -6,6 +6,7 @@ file_identifier "x5f2";
 table Status {
     software_name : string;      // Name of the software publishing the status message
     software_version : string;   // Version number of the software publishing the status message
+    service_id : string;         // Configurable identifier for the service, e.g. "forwarder-CSPEC"
     host_name : string;          // Host name to identify where the software is running
     process_id : int32;          // Identify particular process in case there are multiple instances of the same software running on the same system
     update_interval : int32;     // Update interval in milliseconds for status messages, so consumer knows when to expect another message

--- a/schemas/x5f2_status.fbs
+++ b/schemas/x5f2_status.fbs
@@ -8,8 +8,8 @@ table Status {
     software_version : string;   // Version number of the software publishing the status message
     service_id : string;         // Configurable identifier for the service, e.g. "forwarder-CSPEC"
     host_name : string;          // Host name to identify where the software is running
-    process_id : int32;          // Identify particular process in case there are multiple instances of the same software running on the same system
-    update_interval : int32;     // Update interval in milliseconds for status messages, so consumer knows when to expect another message
+    process_id : uint32;         // Identify particular process in case there are multiple instances of the same software running on the same system
+    update_interval : uint32;    // Update interval in milliseconds for status messages, so consumer knows when to expect another message
     status_json : string;        // Status information specific to the software publishing this message, in JSON format
 }
 

--- a/schemas/x5f2_status.fbs
+++ b/schemas/x5f2_status.fbs
@@ -6,7 +6,7 @@ file_identifier "x5f2";
 table Status {
     software_name : string;      // Name of the software publishing the status message
     software_version : string;   // Version number of the software publishing the status message
-    system_name : string;        // System name to identify where the software is running
+    host_name : string;          // Host name to identify where the software is running
     process_id : int32;          // Identify particular process in case there are multiple instances of the same software running on the same system
     update_interval : int32;     // Update interval in milliseconds for status messages, so consumer knows when to expect another message
     status_json : string;        // Status information specific to the software publishing this message, in JSON format

--- a/schemas/x5f2_status.fbs
+++ b/schemas/x5f2_status.fbs
@@ -8,7 +8,7 @@ table Status {
     software_version : string;   // Version number of the software publishing the status message
     system_name : string;        // System name to identify where the software is running
     process_id : int32;          // Identify particular process in case there are multiple instances of the same software running on the same system
-    period : int32;              // Update period in seconds for status messages, so consumer knows when to expect another message
+    update_interval : int32;     // Update interval in milliseconds for status messages, so consumer knows when to expect another message
     status_json : string;        // Status information specific to the software publishing this message, in JSON format
 }
 


### PR DESCRIPTION
### Description of Work

Adds a schema for status messages. Contains a JSON string field for application-specific details such that it should be flexible enough to use in any of our software.

### Issue

Part of DM-1896

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


