### PR TITLE
Add 64 bit int types now supported by EPICS

### DIFF
--- a/schemas/NDAr_NDArray_schema.fbs
+++ b/schemas/NDAr_NDArray_schema.fbs
@@ -5,7 +5,7 @@ namespace FB_Tables;
 
 file_identifier "NDAr";
 
-enum DType : byte { Int8, Uint8, Int16, Uint16, Int32, Uint32, Float32, Float64, c_string }
+enum DType : byte { Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Float32, Float64, c_string }
 
 struct epicsTimeStamp {
     secPastEpoch : int;


### PR DESCRIPTION
### Description of Work

EPICS now supports 64 bit integer types for area detector.
Requested by Freddie.
Discussed in In-Kind meeting 2020-04-30 and agreed we try to make the change without changing the identifier (despite technically being a breaking change) on the basis that it is not in active use.

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


