### PR TITLE
Name CacheEntry differently to ns10

### DIFF
--- a/schemas/ns11_typed_cache_entry.fbs
+++ b/schemas/ns11_typed_cache_entry.fbs
@@ -37,7 +37,7 @@ table Array {
 }
 
 /// pylint: skip-file
-table CacheEntry {
+table TypedCacheEntry {
         key: string;            // key for this entry (usually nicos/device/parameter)
         time: double;           // time (in seconds after epoch) when this entry was set
         ttl: double;            // time to live (in seconds after time field of this entry). NOT TO BE USED OUTSIDE OF NICOS!
@@ -45,4 +45,4 @@ table CacheEntry {
         value: Value;
 }
 
-root_type CacheEntry;
+root_type TypedCacheEntry;


### PR DESCRIPTION
### Description of Work

@mkoennecke suggested renaming it so as to avoid stupid mistakes, so I have done it.

Technically it is a breaking change but as nobody is using it...

### Issue

DM-1225

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


