### PR TITLE
Add schema for Forwarder config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Including e.g. the schema id in the namespace name avoids any collision.
 
 ## Backwards compatibility
 
-Please, avoid changes which break binary compatibility. Flatbuffers documentation contains good information about how to maintain binary compatibility. If you need to make breaking changes to schemas that are not under development, acquire a new schema id.
+Please, avoid changes which break binary compatibility. FlatBuffers documentation contains good information about how to maintain binary compatibility. If you need to make breaking changes to schemas that are not under development, acquire a new schema id.
 
 Schemas that are under development should be clearly marked as such in the schema file and in the **Schema ids** below to warn users of possible loss of backwards compatibility.
 
@@ -48,7 +48,7 @@ and work with the flat buffers union data type in your root element.
 
 Please prefix your schema files in this repository with your chosen schema id
 so that we can easily avoid id collisions.
-Tables should use UpperCamelCase and fields should use snake_case. Try to keep names consistent with equivalient fields in existing schema.
+Tables should use UpperCamelCase and fields should use snake_case. Try to keep names consistent with equivalent fields in existing schema.
 
 
 ## Schema ids
@@ -70,8 +70,8 @@ ai34        ai34_det_counts.fbs               Counts on each detector pixel from
 senv        senv_data.fbs                     Used for storing for waveforms from DG ADC readout system.
 NDAr        NDAr_NDArray_schema.fbs           Holds binary blob of data with n dimensions.
 mo01        mo01_nmx.fbs                      Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks.
-ns10        ns10_cache_entry.fbs              Nicos cache entry
-ns11        ns11_typed_cache_entry.fbs        Nicos cache entry with typed data
+ns10        ns10_cache_entry.fbs              NICOS cache entry
+ns11        ns11_typed_cache_entry.fbs        NICOS cache entry with typed data
 hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
@@ -80,6 +80,7 @@ tdct        tdct_timestamps.fbs               Timestamps from a device (e.g. a c
 pl72        pl72_run_start.fbs                File writing, run start message for file writer and Mantid
 6s4t        6s4t_run_stop.fbs                 File writing, run stop message for file writer and Mantid
 x5f2        x5f2_status.fbs                   Status update and heartbeat message for any software
+rf5k        rf5k_forwarder_config.fbs         Configuration update for Forwarder
 ```
 
 ## Useful information:

--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -1,5 +1,9 @@
 // Forwarder Configuration Update
 // Add or remove channels from a Forwarder configuration
+//
+// Typical producers and consumers:
+// Produced by NICOS
+// Consumed by Forwarder
 
 file_identifier "rf5k";
 

--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -19,7 +19,6 @@ table Stream {
 table ConfigUpdate {
     config_change: UpdateType;   // Type of config change, add streams, remove streams or remove all streams
     streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
-    source_name: string;         // Some string so that we can identify where this message came from if we need to
 }
 
 root_type ConfigUpdate;

--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -1,0 +1,23 @@
+// Forwarder Configuration Update
+// Add or remove channels from a Forwarder configuration
+
+file_identifier "rf5k";
+
+enum UpdateType: ushort {
+  ADD,
+  REMOVE,
+  REMOVEALL
+}
+
+table Stream {
+  channel: string;   // Name of the EPICS channel/pv (e.g. "MYIOC:VALUE1")
+  // If config_change=REMOVE then schema and topic are not used, all configurations for given channel name will be removed
+  schema: string;    // Identify the output format for updates from the named channel (e.g. "f142" or "TdcTime")
+  topic: string;     // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
+}
+
+table ConfigUpdate {
+    config_change: UpdateType;   // Type of config change, add streams, remove streams or remove all streams
+    streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
+    source_name: string;         // Some string so that we can identify where this message came from if we need to
+}

--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -21,3 +21,5 @@ table ConfigUpdate {
     streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
     source_name: string;         // Some string so that we can identify where this message came from if we need to
 }
+
+root_type ConfigUpdate;


### PR DESCRIPTION
### Description of Work

Adds a FlatBuffer schema for configuration changes of the Forwarder.
Closely resembles the JSON message it will replace.

The last JSON message to replace with FlatBuffers!

### Issue

Required for DM-1901

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


