### PR TITLE
Update rf5k comments

### DIFF
--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -24,6 +24,8 @@ table Stream {
   // If config_change=REMOVE then at least one of the string fields must be populated,
   // and the Forwarder will remove any streams which match all of the populated string fields.
   // "populated" here means supplying a non-empty string for the field.
+  // Wildcards '?' (single character) and '*' (multi-character) can be used to match topic or channel name,
+  // Wildcards cannot be used to match schema as they are valid characters in schema identifiers.
   channel: string;           // Name of the EPICS channel/pv (e.g. "MYIOC:VALUE1")
   schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "TdcTime")
   topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")

--- a/schemas/rf5k_forwarder_config.fbs
+++ b/schemas/rf5k_forwarder_config.fbs
@@ -20,8 +20,11 @@ enum Protocol: ushort {
 }
 
 table Stream {
+  // If config_change=ADD then all fields of Stream must be populated.
+  // If config_change=REMOVE then at least one of the string fields must be populated,
+  // and the Forwarder will remove any streams which match all of the populated string fields.
+  // "populated" here means supplying a non-empty string for the field.
   channel: string;           // Name of the EPICS channel/pv (e.g. "MYIOC:VALUE1")
-  // If config_change=REMOVE then schema and topic are not used, all configurations for given channel name will be removed
   schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "TdcTime")
   topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
   protocol: Protocol = PVA;  // Protocol for channel, EPICS PV access by default


### PR DESCRIPTION
### Description of Work

Updated the comments in rf5k schema to reflect the new feature added to the Forwarder here: https://github.com/ess-dmsc/forwarder/pull/43
This addresses the requests made in #57 to support removing streams from the Forwarder by details other than PV name and to allow use of wildcards, which was also previously requested in DM-1634.

This changes only comments in the schema; it is a non-breaking change and does not require a new identifier.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

Please check that the new comment is clear.

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


