### PR TITLE
Update to flatbuffers 1.12.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.PipelineBuilder
 project = "streaming-data-types"
 
 container_build_nodes = [
-  'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7')
+  'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8')
 ]
 
 pipeline_builder = new PipelineBuilder(this, container_build_nodes)
@@ -22,11 +22,12 @@ builders = pipeline_builder.createBuilders { container ->
     }  // stage
 
     pipeline_builder.stage("${container.key}: get dependencies") {
+        // Rebuild flatc otherwise package from conan center remote is built against wrong version of glibc
         container.sh """
             mkdir build
             cd build
             conan remote add --insert 0 ess-dmsc-local ${local_conan_server}
-            conan install --generator virtualrunenv flatbuffers/1.11.0@google/stable --build=outdated
+            conan install ../${project}/conanfile.txt --build=outdated --build=flatc
         """
     }  // stage
     

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,8 @@
+[requires]
+flatbuffers/1.12.0
+
+[build_requires]
+flatc/1.12.0
+
+[generators]
+virtualrunenv


### PR DESCRIPTION
### Description of Work

The `flatc` executable, used to generate the header files, is now a separate conan package which can be used in `build_requires` and won't get unecessarily propagated through to our applications.

### Issue

*If there is an associated issue, write 'Closes #XXX'*

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

Version update only, doesn't need to go through the schema gatekeepers.


