### PR TITLE
Add and modify schemas to support responses to commands/messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ json        json_json.fbs                     Carries a JSON payload
 tdct        tdct_timestamps.fbs               Timestamps from a device (e.g. a chopper)
 pl72        pl72_run_start.fbs                File writing, run start message for file writer and Mantid
 6s4t        6s4t_run_stop.fbs                 File writing, run stop message for file writer and Mantid
-answ        answ_action_response.fbs          Holds the result of a command to or state change of the filewriter.
+answ        answ_action_response.fbs          Holds the result of a command to the filewriter.
+wrdn        wrdn_finished_writing.fbs         Message from the filewriter when it is done writing a file.
 x5f2        x5f2_status.fbs                   Status update and heartbeat message for any software
 rf5k        rf5k_forwarder_config.fbs         Configuration update for Forwarder
 ```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ json        json_json.fbs                     Carries a JSON payload
 tdct        tdct_timestamps.fbs               Timestamps from a device (e.g. a chopper)
 pl72        pl72_run_start.fbs                File writing, run start message for file writer and Mantid
 6s4t        6s4t_run_stop.fbs                 File writing, run stop message for file writer and Mantid
+answ        answ_action_response.fbs          Holds the result of a command to or state change of the filewriter.
 x5f2        x5f2_status.fbs                   Status update and heartbeat message for any software
 rf5k        rf5k_forwarder_config.fbs         Configuration update for Forwarder
 ```

--- a/schemas/6s4t_run_stop.fbs
+++ b/schemas/6s4t_run_stop.fbs
@@ -14,7 +14,7 @@ table RunStop {              //  *Mantid*    // *File Writer* // *Description*
     run_name : string;       //  Required    //  Unused       // Name for the run, must match corresponding field in RunStart
     job_id : string;         //  Unused      //  Required     // A unique identifier for the file writing job
     service_id : string;     //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
-    command_id : string;     //  Unused      //  Required     // Required for uniquely identifying a stop command
+    command_id : string;     //  Unused      //  Required     // Required for uniquely identifying a stop command. Enforcement of the uniqueness will be limited but done by the filewriter.
 }
 
 root_type RunStop;

--- a/schemas/6s4t_run_stop.fbs
+++ b/schemas/6s4t_run_stop.fbs
@@ -10,10 +10,11 @@
 file_identifier "6s4t";
 
 table RunStop {              //  *Mantid*    // *File Writer* // *Description*
-    stop_time : uint64;      //  Required    //  Required     // milliseconds since Unix epoch (1 Jan 1970)
+    stop_time : uint64;      //  Required    //  Required     // milliseconds since Unix epoch (1 Jan 1970). When set to 0, will trigger a "stop NOW" code path in the file writer.
     run_name : string;       //  Required    //  Unused       // Name for the run, must match corresponding field in RunStart
     job_id : string;         //  Unused      //  Required     // A unique identifier for the file writing job
     service_id : string;     //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
+    command_id : string;     //  Unused      //  Required     // Required for uniquely identifying a stop command
 }
 
 root_type RunStop;

--- a/schemas/answ_action_response.fbs
+++ b/schemas/answ_action_response.fbs
@@ -2,7 +2,7 @@
 
 file_identifier "answ";
 
-enum ActionType : byte { StartJob = 0, SetStopTime, StopNow, HasStopped }
+enum ActionType : byte { StartJob = 0, SetStopTime }
 enum ActionOutcome : byte { Success = 0, Failure }
 
 table ActionResponse {
@@ -10,8 +10,9 @@ table ActionResponse {
     job_id : string (required);           // A unique identifier for the file writing job
     action : ActionType;                  // What type of command is this a response to?
     outcome : ActionOutcome;              // Was the command accepted (action successfull)?
+    stop_time : uint64;                   // Holds the current stop time of the job
     message : string;                     // Must hold an error message if outcome was "Failure", is optional otherwise.
-    command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id. In the case of an "has stopped message", this field may be ignored. 
+    command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id.
 }
 
 root_type ActionResponse;

--- a/schemas/answ_action_response.fbs
+++ b/schemas/answ_action_response.fbs
@@ -10,6 +10,7 @@ table ActionResponse {
     job_id : string (required);           // A unique identifier for the file writing job
     action : ActionType;                  // What type of command is this a response to?
     outcome : ActionOutcome;              // Was the command accepted (action successfull)?
+    status_code: int32;                   // A status/response code modelled on the HTTP status codes.
     stop_time : uint64;                   // Holds the current stop time of the job
     message : string;                     // Must hold an error message if outcome was "Failure", is optional otherwise.
     command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id.

--- a/schemas/answ_action_response.fbs
+++ b/schemas/answ_action_response.fbs
@@ -6,12 +6,12 @@ enum ActionType : byte { StartJob = 0, SetStopTime, StopNow, HasStopped }
 enum ActionOutcome : byte { Success = 0, Failure }
 
 table ActionResponse {
-    service_id : string (required);       // The identifier for the instance of the file-writer that respnded to the command
+    service_id : string (required);       // The identifier for the instance of the file-writer that responded to the command
     job_id : string (required);           // A unique identifier for the file writing job
     action : ActionType;                  // What type of command is this a response to?
     outcome : ActionOutcome;              // Was the command accepted (action successfull)?
     message : string;                     // Must hold an error message if outcome was "Failure", is optional otherwise.
-    command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id. In the case of an "has stopped message", this field may be ignored.
+    command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id. In the case of an "has stopped message", this field may be ignored. 
 }
 
 root_type ActionResponse;

--- a/schemas/answ_action_response.fbs
+++ b/schemas/answ_action_response.fbs
@@ -1,0 +1,16 @@
+// A message for holding information on the (immediate) outcome of a command to (or state change of) a filewriter
+
+file_identifier "answ";
+
+enum ActionType : byte { StartJob = 0, SetStopTime, StopNow, HasStopped }
+enum ActionOutcome : byte { Success = 0, Failure }
+
+table ActionResponse {
+    service_id : string (required);       // The identifier for the instance of the file-writer that respnded to the command
+    job_id : string (required);           // A unique identifier for the file writing job
+    action : ActionType;                  // What type of command is this a response to?
+    outcome : ActionOutcome;              // Was the command accepted (action successfull)?
+    message : string;                     // Must hold an error message if outcome was "Failure", is optional otherwise.
+}
+
+root_type ActionResponse;

--- a/schemas/answ_action_response.fbs
+++ b/schemas/answ_action_response.fbs
@@ -11,6 +11,7 @@ table ActionResponse {
     action : ActionType;                  // What type of command is this a response to?
     outcome : ActionOutcome;              // Was the command accepted (action successfull)?
     message : string;                     // Must hold an error message if outcome was "Failure", is optional otherwise.
+    command_id : string;                  // Holds an id that is unique to the command that this is the response to. In the case of start commands, the id is the job-id. In the case of an "has stopped message", this field may be ignored.
 }
 
 root_type ActionResponse;

--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -26,6 +26,7 @@ table RunStart {                                     //  *Mantid*    // *File Wr
     n_periods : uint32 = 1;                          //  Optional    //  Unused       // Number of periods (ISIS only)
                                                                                       // Periods provide a way to segregate data at the data acquisition stage
     detector_spectrum_map: SpectraDetectorMapping;   //  Optional    //  Unused       // Map spectrum numbers in the event messages to detector IDs in the instrument definition (optional, for ISIS only)
+    metadata : string;                               //  Unused      //  Optional     // Holds a JSON string with (static) metadata about the measurement. E.g. proposal id.
 }
 
 root_type RunStart;

--- a/schemas/wrdn_finished_writing.fbs
+++ b/schemas/wrdn_finished_writing.fbs
@@ -1,0 +1,14 @@
+// A message to tell the world that the (current) filewriter is done writing to file (for whatever reason).
+
+file_identifier "wrdn";
+
+table FinishedWriting {
+    service_id : string (required);     // milliseconds since Unix epoch (1 Jan 1970). When set to 0, will trigger a "stop NOW" code path in the file writer.
+    job_id : string (required);         // The unique identifier of the file writing job
+    error_encountered : bool;           // True if stopped due to error
+    file_name : string (required);      // Name of file that was just closed.
+    metadata : string;                  // JSON string with metadata about the file that was just closed.
+    message : string;                   // Must hold an error message if filewriting was stopped due to an error, is optional otherwise.
+}
+
+root_type FinishedWriting;


### PR DESCRIPTION
### Description of Work

* Added a response schema that is used by the file-writer to respond to a command
* Added a ``command_id`` field to the "stop" schema in order to uniquely identify it.
* Added documentation for handing a special case _stop-time_ in the file-writer that is useful in system testing.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Matthew J have given their explicit approval in the comments section.


