### PR TITLE
Replace NDAr schema with ADAr

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid
 ai33        ai33_det_count_imgs.fbs           Accumulated counts of detection events
 ai34        ai34_det_counts.fbs               Counts on each detector pixel from a single pulse
 senv        senv_data.fbs                     Used for storing for waveforms from DG ADC readout system.
-NDAr        NDAr_NDArray_schema.fbs           Holds binary blob of data with n dimensions.
+NDAr        NDAr_NDArray_schema.fbs           (DEPRECATED) Holds binary blob of data with n dimensions.
+ADAr        ADAr_area_detector_array.fbs      Holds EPICS area detector array data (in a flatbuffer format).
 mo01        mo01_nmx.fbs                      Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks.
 ns10        ns10_cache_entry.fbs              NICOS cache entry
 ns11        ns11_typed_cache_entry.fbs        NICOS cache entry with typed data

--- a/schemas/ADAr_area_detector_array.fbs
+++ b/schemas/ADAr_area_detector_array.fbs
@@ -1,0 +1,26 @@
+
+// A flatbuffer schema for holding EPICS area detector updates
+
+file_identifier "ADAr";
+
+enum DType:byte { int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64, c_string }
+
+table Attribute {
+    name: string (required);   // Name of attribute
+    description: string;       // Description of attribute
+    source: string;            // EPICS PV name or DRV_INFO string of attribute
+    data_type: DType;          // The type of the data (value) in this attribute
+    data: [ubyte] (required);  // The data/value of the attribute
+}
+
+table ADArray {
+    source_name: string (required); // Source name of array
+    id: int;                        // Unique id to this particular NDArray
+    timestamp: ulong;               // Timestamp in nanoseconds since UNIX epoch
+    dimensions: [ulong] (required); // Dimensions of the array
+    data_type: DType;               // The type of the data stored in the array
+    data: [ubyte] (required);       // Elements in the array
+    attributes: [Attribute];        // Extra metadata about the array
+}
+
+root_type ADArray;

--- a/schemas/NDAr_NDArray_schema.fbs
+++ b/schemas/NDAr_NDArray_schema.fbs
@@ -1,4 +1,6 @@
 
+// NOTE: THIS SCHEMA HAS BEEN DEPRECATED AND WILL BE REMOVED SOON
+
 namespace FB_Tables;
 
 file_identifier "NDAr";


### PR DESCRIPTION
### Description of Work

There are several problems with the original NDAr schema. Mostly due to a lack of (collective) experience and knowledge at the time of its creation. Instead of fixing the NDAr schema I thought it best to simply make a new one, hence: ADAr.

Of course, if you prefer that we make changes to NDAr instead then I can make the relevant changes to the PR.

The following is a list of changes made to improve upon NDAr:

* Removal of use of namespaces as those can be problematic when using flatbuffers with Python.
* Changed the names of all fields to better mirror the names in other schemas.
* Fix timestamps to (only) be in nanoseconds since unix epoch.

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.