### PR TITLE
Strings removed from f142.

### DIFF
--- a/schemas/f142_logdata.fbs
+++ b/schemas/f142_logdata.fbs
@@ -18,7 +18,6 @@ table Long   { value:  long;   }
 table ULong  { value: ulong;   }
 table Float  { value:  float;  }
 table Double { value:  double; }
-table String { value: string; }
 
 table ArrayByte   { value: [ byte];   }
 table ArrayUByte  { value: [ubyte];   }
@@ -30,7 +29,6 @@ table ArrayLong   { value: [ long];   }
 table ArrayULong  { value: [ulong];   }
 table ArrayFloat  { value: [ float];  }
 table ArrayDouble { value: [ double]; }
-table ArrayString { value: [string]; }
 
 union Value {
 	Byte,
@@ -53,11 +51,6 @@ union Value {
 	ArrayULong,
 	ArrayFloat,
 	ArrayDouble,
-
-	// NOTE
-	// FlatBuffers does not specify encoding, but we require it to be utf8.
-	String,
-	ArrayString
 }
 
 enum AlarmStatus: ushort {


### PR DESCRIPTION
### Description of Work

As the file-writer can not write strings anyway we might as well remove the possibility of storing strings in a f142 flatbuffer. This change will not break backwards compatibility due to the strings (previously) being placed/defined last in the `Value` union.

### Issue

* Closes ECDC-1725

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


