### PR TITLE
Add a field for giving the filewriter a instrument specific cmd/status topic

### DIFF
--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -21,6 +21,7 @@ table RunStart {                                     //  *Mantid*    // *File Wr
                                                                                       // to look up an Instrument Definition File (IDF) based on the instrument name
     job_id : string;                                 //  Unused      //  Required     // A unique identifier for the file writing job
     broker : string;                                 //  Unused      //  Required     // Broker name and port, for example "localhost:9092", from which the file writer should get data
+    instrument_topic : string                        //  Optional    //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
     service_id : string;                             //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
     filename : string;                               //  Unused      //  Required     // Name of the file to write, for example run_1234.nxs
     n_periods : uint32 = 1;                          //  Optional    //  Unused       // Number of periods (ISIS only)

--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -21,7 +21,7 @@ table RunStart {                                     //  *Mantid*    // *File Wr
                                                                                       // to look up an Instrument Definition File (IDF) based on the instrument name
     job_id : string;                                 //  Unused      //  Required     // A unique identifier for the file writing job
     broker : string;                                 //  Unused      //  Required     // Broker name and port, for example "localhost:9092", from which the file writer should get data
-    instrument_topic : string                        //  Optional    //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
+    instrument_topic : string                        //  Unused      //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
     service_id : string;                             //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
     filename : string;                               //  Unused      //  Required     // Name of the file to write, for example run_1234.nxs
     n_periods : uint32 = 1;                          //  Optional    //  Unused       // Number of periods (ISIS only)

--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -27,7 +27,7 @@ table RunStart {                                     //  *Mantid*    // *File Wr
                                                                                       // Periods provide a way to segregate data at the data acquisition stage
     detector_spectrum_map: SpectraDetectorMapping;   //  Optional    //  Unused       // Map spectrum numbers in the event messages to detector IDs in the instrument definition (optional, for ISIS only)
     metadata : string;                               //  Unused      //  Optional     // Holds a JSON string with (static) metadata about the measurement. E.g. proposal id.
-    control_topic : string                        //  Unused      //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
+    control_topic : string;                          //  Unused      //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
 }
 
 root_type RunStart;

--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -21,13 +21,13 @@ table RunStart {                                     //  *Mantid*    // *File Wr
                                                                                       // to look up an Instrument Definition File (IDF) based on the instrument name
     job_id : string;                                 //  Unused      //  Required     // A unique identifier for the file writing job
     broker : string;                                 //  Unused      //  Required     // Broker name and port, for example "localhost:9092", from which the file writer should get data
-    instrument_topic : string                        //  Unused      //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
     service_id : string;                             //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
     filename : string;                               //  Unused      //  Required     // Name of the file to write, for example run_1234.nxs
     n_periods : uint32 = 1;                          //  Optional    //  Unused       // Number of periods (ISIS only)
                                                                                       // Periods provide a way to segregate data at the data acquisition stage
     detector_spectrum_map: SpectraDetectorMapping;   //  Optional    //  Unused       // Map spectrum numbers in the event messages to detector IDs in the instrument definition (optional, for ISIS only)
     metadata : string;                               //  Unused      //  Optional     // Holds a JSON string with (static) metadata about the measurement. E.g. proposal id.
+    control_topic : string                        //  Unused      //  Optional     // Topic on which the File Writer will listen for further commands and publish status messages when started from a pool
 }
 
 root_type RunStart;


### PR DESCRIPTION
### Description of Work

In the filewriter pool scenario, on starting a job we want to be able to have the chosen filewriter switch to listening and writing to the specific instrument topic rather than the general "pool" topics

### Issue

Part of ECDC-2606

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


