### PR TITLE
added ev43 to support fast pulse rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ f140        f140_general.fbs                  [OBSOLETE] Can encode an arbitrary
 f141        f141_ntarraydouble.fbs            [OBSOLETE] A simple array of double, testing file writing
 f142        f142_logdata.fbs                  For log data, for example forwarded EPICS PV update
 f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
-ev42        ev42_events.fbs                   Multi-institution neutron event data
-ev43        ev43_events.fbs                   Multi-institution neutron event data to support fast pulse rates
+ev42        ev42_events.fbs                   Multi-institution neutron event data for a single pulse
+ev43        ev43_events.fbs                   Multi-institution neutron event data from multiple pulses
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
 ba57        ba57_run_info.fbs                 [OBSOLETE] Run start/stop information for Mantid [superceded by pl72]
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ f141        f141_ntarraydouble.fbs            [OBSOLETE] A simple array of doubl
 f142        f142_logdata.fbs                  For log data, for example forwarded EPICS PV update
 f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
 ev42        ev42_events.fbs                   Multi-institution neutron event data
+ev43        ev43_events.fbs                   Multi-institution neutron event data to support fast pulse rates
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
 ba57        ba57_run_info.fbs                 [OBSOLETE] Run start/stop information for Mantid [superceded by pl72]
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid

--- a/schemas/ev43_events.fbs
+++ b/schemas/ev43_events.fbs
@@ -1,0 +1,23 @@
+// Schema for neutron detection event data
+
+include "is84_isis_events.fbs";
+include "dtdb_adc_pulse_debug.fbs";
+
+file_identifier "ev43";
+
+union FacilityData { ArrayISISData, AdcPulseDebug }
+
+table EventMessage {
+    source_name : string;    // optional field identifying the producer type, for example detector type
+    message_id : ulong;      // consecutive numbers, to detect missing or unordered messages
+    pulse_time : [ulong];    // Nanoseconds since Unix epoch (1 Jan 1970)
+                             // If a pulse times are available in the aquisition system, this field holds
+                             // that timestamps. Holds wall time otherwise.
+    pulse_index : [uint];    // Maps the pulse time to the start of the neutron events linked to the pulse
+    time_of_flight : [uint]; // Nanoseconds
+                             // Time of flight for each event if pulse time is available. If not, a
+                             // (positive) offset from the wall time stored in the `pulse_time`.
+    detector_id : [uint];    // Identifiers that represent the positions of the events in the detector(s).
+    facility_specific_data : FacilityData;  // optional field
+}
+root_type EventMessage;

--- a/schemas/ev43_events.fbs
+++ b/schemas/ev43_events.fbs
@@ -1,23 +1,18 @@
-// Schema for neutron detection event data
-
-include "is84_isis_events.fbs";
-include "dtdb_adc_pulse_debug.fbs";
+// Schema for neutron detection event data with multiple pulse events
 
 file_identifier "ev43";
-
-union FacilityData { ArrayISISData, AdcPulseDebug }
 
 table EventMessage {
     source_name : string;    // optional field identifying the producer type, for example detector type
     message_id : ulong;      // consecutive numbers, to detect missing or unordered messages
     pulse_time : [ulong];    // Nanoseconds since Unix epoch (1 Jan 1970)
-                             // If a pulse times are available in the aquisition system, this field holds
-                             // that timestamps. Holds wall time otherwise.
-    pulse_index : [uint];    // Maps the pulse time to the start of the neutron events linked to the pulse
+                             // If pulse times are available in the aquisition system, this field holds
+                             // those timestamps. Holds wall time otherwise.
+    pulse_index : [uint];    // Index into the array for the start of the neutron events linked to the 
+                             // corresponding pulse time. Pulse index and pulse time are the same length.
     time_of_flight : [uint]; // Nanoseconds
                              // Time of flight for each event if pulse time is available. If not, a
                              // (positive) offset from the wall time stored in the `pulse_time`.
     detector_id : [uint];    // Identifiers that represent the positions of the events in the detector(s).
-    facility_specific_data : FacilityData;  // optional field
 }
 root_type EventMessage;

--- a/schemas/is84_isis_events.fbs
+++ b/schemas/is84_isis_events.fbs
@@ -9,3 +9,10 @@ table ISISData {
   run_state : RunState;  // current instrument run state
   proton_charge : float; // at ESS this will likely come through EPICS forwarder instead
 }
+
+// a simple array variant that can be embedded in the facility data for ev43 
+table ArrayISISData {
+  period_number : [uint];
+  run_state : RunState;   // do not anticipate the run state changing in the message lifetime  
+  proton_charge : [float]; 
+}

--- a/schemas/is84_isis_events.fbs
+++ b/schemas/is84_isis_events.fbs
@@ -9,10 +9,3 @@ table ISISData {
   run_state : RunState;  // current instrument run state
   proton_charge : float; // at ESS this will likely come through EPICS forwarder instead
 }
-
-// a simple array variant that can be embedded in the facility data for ev43 
-table ArrayISISData {
-  period_number : [uint];
-  run_state : RunState;   // do not anticipate the run state changing in the message lifetime  
-  proton_charge : [float]; 
-}


### PR DESCRIPTION
### Description of Work

Added ev43 schema to support instruments with fast pulse rates that allow for more efficient data transfer. 

### Issue

No documented issue but comes about from framework evaluation at Ansto.

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new)*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


