### PR TITLE
added namespace to ev43 schema

### DIFF
--- a/schemas/ev43_events.fbs
+++ b/schemas/ev43_events.fbs
@@ -2,9 +2,7 @@
 
 file_identifier "ev43";
 
-namespace ev43;
-
-table EventMessage {
+table Event43Message {
     source_name : string;    // optional field identifying the producer type, for example detector type
     message_id : ulong;      // consecutive numbers, to detect missing or unordered messages
     pulse_time : [ulong];    // Nanoseconds since Unix epoch (1 Jan 1970)
@@ -17,4 +15,4 @@ table EventMessage {
                              // (positive) offset from the wall time stored in the `pulse_time`.
     detector_id : [uint];    // Identifiers that represent the positions of the events in the detector(s).
 }
-root_type EventMessage;
+root_type Event43Message;

--- a/schemas/ev43_events.fbs
+++ b/schemas/ev43_events.fbs
@@ -2,6 +2,8 @@
 
 file_identifier "ev43";
 
+namespace ev43;
+
 table EventMessage {
     source_name : string;    // optional field identifying the producer type, for example detector type
     message_id : ulong;      // consecutive numbers, to detect missing or unordered messages


### PR DESCRIPTION
### Description of Work

Added a namespace to the ev43 schema to avoid conflict with the ev42 schema in the generated c++ header files.

### Issue

Event message ambiguity between the ev42 and ev43 generated header files. 

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new) - please make sure the ID starts with a letter!*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


