### PR TITLE
New schema ev44_events to replave ev42 and ev43

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ f142        f142_logdata.fbs                  For log data, for example forwarde
 f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
 ev42        ev42_events.fbs                   Multi-institution neutron event data for a single pulse
 ev43        ev43_events.fbs                   Multi-institution neutron event data from multiple pulses
+ev44        ev44_events.fbs                   Multi-institution neutron event data
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
 ba57        ba57_run_info.fbs                 [OBSOLETE] Run start/stop information for Mantid [superceded by pl72]
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid
@@ -71,7 +72,8 @@ ADAr        ADAr_area_detector_array.fbs      Holds EPICS area detector array da
 mo01        mo01_nmx.fbs                      Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks.
 ns10        ns10_cache_entry.fbs              NICOS cache entry
 ns11        ns11_typed_cache_entry.fbs        NICOS cache entry with typed data
-hs00        hs00_event_histogram.fbs          Event histogram stored in n dim array
+hs00        hs00_event_histogram.fbs          (DEPRECATED) Event histogram stored in n dim array [superceded by hs01]
+hs01        hs01_event_histogram.fbs          Event histogram stored in n dim array
 dtdb        dtdb_adc_pulse_debug.fbs          Debug fields that can be added to the ev42 schema
 ep00        ep00_epics_connection_info.fbs    Status of the EPICS connection
 json        json_json.fbs                     Carries a JSON payload

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ f142        f142_logdata.fbs                  For log data, for example forwarde
 f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
 ev42        ev42_events.fbs                   Multi-institution neutron event data for a single pulse
 ev43        ev43_events.fbs                   Multi-institution neutron event data from multiple pulses
-ev44        ev44_events.fbs                   Multi-institution neutron event data for both single and multpole pulses
+ev44        ev44_events.fbs                   Multi-institution neutron event data for both single and multiple pulses
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
 ba57        ba57_run_info.fbs                 [OBSOLETE] Run start/stop information for Mantid [superceded by pl72]
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ f142        f142_logdata.fbs                  For log data, for example forwarde
 f143        f143_structure.fbs                [OBSOLETE] Arbitrary nested data
 ev42        ev42_events.fbs                   Multi-institution neutron event data for a single pulse
 ev43        ev43_events.fbs                   Multi-institution neutron event data from multiple pulses
-ev44        ev44_events.fbs                   Multi-institution neutron event data
+ev44        ev44_events.fbs                   Multi-institution neutron event data for both single and multpole pulses
 is84        is84_isis_events.fbs              ISIS specific addition to event messages
 ba57        ba57_run_info.fbs                 [OBSOLETE] Run start/stop information for Mantid [superceded by pl72]
 df12        df12_det_spec_map.fbs             Detector-spectrum map for Mantid

--- a/schemas/ev44_events.fbs
+++ b/schemas/ev44_events.fbs
@@ -3,16 +3,17 @@
 file_identifier "ev44";
 
 table Event44Message {
-    source_name : string (required);    // optional field identifying the producer type, for example detector type
-    pulse_time : [long] (required);                // Nanoseconds since Unix epoch (1 Jan 1970)
-                                        // If a pulse times are available in the aquisition system, this field holds
-                                        // those timestamps. Holds wall time otherwise.
-    pulse_index : [int] (required);                // Index into the array for the start of the neutron events linked to the 
-                                        // corresponding pulse time. Pulse index and pulse time are the same length.
-    time_of_flight : [int];             // Nanoseconds
-                                        // Time of flight for each event if pulse time is available. If not, a
-                                        // (positive) offset from the wall time stored in the `pulse_time`.
-    pixel_id : [int];                   // Identifiers that represent the positions of the events in the detector(s).
+    source_name : string (required);            // optional field identifying the producer type, for example detector type
+    reference_time : [long] (required);         // Nanoseconds since Unix epoch (1 Jan 1970)
+                                                // If pulse times are available in the aquisition system, this field holds
+                                                // those timestamps. Holds wall time otherwise.
+    reference_time_index : [int] (required);    // Index into the array for the start of the neutron events linked to the 
+                                                // corresponding pulse/reference time. reference_time_index and reference_time 
+                                                // are the same length.
+    time_of_flight : [int];                     // Nanoseconds
+                                                // Time of flight for each event if pulse time is available. If not, a
+                                                // (positive) offset from the wall time stored in the `reference_time`.
+    pixel_id : [int];                           // Identifiers that represent the positions of the events in the detector(s).
 }
 
 root_type Event44Message;

--- a/schemas/ev44_events.fbs
+++ b/schemas/ev44_events.fbs
@@ -15,4 +15,4 @@ table Event44Message {
     pixel_id : [int];                   // Identifiers that represent the positions of the events in the detector(s).
 }
 
-root_type EventMessage;
+root_type Event44Message;

--- a/schemas/ev44_events.fbs
+++ b/schemas/ev44_events.fbs
@@ -1,0 +1,18 @@
+// Schema for neutron detection event data
+
+file_identifier "ev44";
+
+table Event44Message {
+    source_name : string (required);    // optional field identifying the producer type, for example detector type
+    pulse_time : [long] (required);                // Nanoseconds since Unix epoch (1 Jan 1970)
+                                        // If a pulse times are available in the aquisition system, this field holds
+                                        // those timestamps. Holds wall time otherwise.
+    pulse_index : [int] (required);                // Index into the array for the start of the neutron events linked to the 
+                                        // corresponding pulse time. Pulse index and pulse time are the same length.
+    time_of_flight : [int];             // Nanoseconds
+                                        // Time of flight for each event if pulse time is available. If not, a
+                                        // (positive) offset from the wall time stored in the `pulse_time`.
+    pixel_id : [int];                   // Identifiers that represent the positions of the events in the detector(s).
+}
+
+root_type EventMessage;

--- a/schemas/hs01_event_histogram.fbs
+++ b/schemas/hs01_event_histogram.fbs
@@ -1,0 +1,49 @@
+// General schema for histogram
+
+file_identifier "hs01";
+
+table ArrayInt   { value: [int];    }
+table ArrayLong  { value: [long];   }
+table ArrayDouble { value: [double];  }
+table ArrayFloat  { value: [float];   }
+
+// Union of allowed data types for the arrays
+union Array {
+    ArrayInt,
+    ArrayLong,
+    ArrayDouble,
+    ArrayFloat,
+}
+
+// Meta information for one dimension
+table DimensionMetaData {
+    length: int;            // Length of the full histogram along this dimension
+    unit: string;           // Unit
+    label: string;          // Label
+    bin_boundaries: Array;  // Boundary information (should be of length: DimensionMetaData.length+1)
+}
+
+// Represents a n-dimensional histogram
+// Subsets of histogram are also supported
+table EventHistogram {
+    source: string;                     // Source name
+    timestamp: long;                    // Timestamp (in ns, after unix epoch)
+    dim_metadata: [DimensionMetaData];  // Meta data for each dimension
+    last_metadata_timestamp: long;      // Timestamp (ns, after unix epoch) when the last metadata information was written
+    current_shape: [int] (required);    // Shape of the current data in each dimension
+    offset: [int];                      // Offset giving the starting index in each dimension
+    data: Array;                        // Data represented in RowMajor order (C Style), filled with 0 if missing
+    errors: Array;                      // Errors in calculation of histogram data (same size as data)
+    info: string;                       // Additional information (Integrated/Processed)
+}
+
+// The "current_shape" and "offset" fields can be used to define a slice of a 
+// larger histogram. This allows breaking a large histogram into multiple messages.
+// For example the dim_metadata could look like this:
+// dim_metadata=[DimensionMetaData(label="x", length=10, ...), DimensionMetaData(label="y", length=10, ...)]
+// and each row could be sent as a separate message by using:
+// current_shape=[10, 1] and offset=[0, 0] in the 1st message
+// current_shape=[10, 1] and offset=[0, 1] in the 2nd message
+// and so on.
+
+root_type EventHistogram;


### PR DESCRIPTION
### Description of Work

Added ev44_events.fbs that replaces ev42 and ev43. Uses signed integer values for compatibility with scipp, and includes the multiple pulses per message functionality from ev43.

### Issue

Closes [ECDC-2914](https://jira.esss.lu.se/browse/ECDC-2914)

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

*A file identifier can be generated [here](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new) - please make sure the ID starts with a letter!*

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


