### PR TITLE
Adding floats and doubles to senv arrays

### DIFF
--- a/schemas/senv_data.fbs
+++ b/schemas/senv_data.fbs
@@ -12,6 +12,8 @@ table Int32Array    { value: [ int] (required);    }
 table UInt32Array   { value: [uint] (required);    }
 table Int64Array   { value: [ long] (required);   }
 table UInt64Array  { value: [ulong] (required);   }
+table ArrayDouble { value: [double] (required);   }
+table ArrayFloat  { value: [float] (required);   }
 
 union ValueUnion {
     Int8Array,
@@ -21,7 +23,9 @@ union ValueUnion {
     Int32Array,
     UInt32Array,
     Int64Array,
-    UInt64Array
+    UInt64Array,
+    ArrayDouble,
+    ArrayFloat
 }
 
 table SampleEnvironmentData {


### PR DESCRIPTION
### Description of Work

The senv schema was updated to be able to handle arrays of floats and doubles, in addition to ints and uints.

### Issue

Jira ticket: https://jira.esss.lu.se/browse/ECDC-3170

When trying to forward the PV YMIR-SETS:SE-BADC-001:VALUE, it was noticed that the senv schema could not handle floats and doubles.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.


## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


