### PR TITLE
Document pl72 Broker field as not required for the File Writer

### DIFF
--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -20,7 +20,7 @@ table RunStart {                                     //  *Mantid*    // *File Wr
                                                                                       // If present Mantid will parse this to get the instrument geometry, otherwise it will attempt
                                                                                       // to look up an Instrument Definition File (IDF) based on the instrument name
     job_id : string;                                 //  Unused      //  Required     // Uuid for the file writing job, serves as job-id.
-    broker : string;                                 //  Unused      //  Required     // Broker name and port, for example "localhost:9092", from which the file writer should get data
+    broker : string;                                 //  Unused      //  Unused       // (Obsolete) Broker name and port, for example "localhost:9092", from which the file writer should get data
     service_id : string;                             //  Unused      //  Optional     // The identifier for the instance of the file-writer that should handle this command
     filename : string;                               //  Unused      //  Required     // Name of the file to write, for example run_1234.nxs
     n_periods : uint32 = 1;                          //  Optional    //  Unused       // Number of periods (ISIS only)


### PR DESCRIPTION
### Description of Work

[We have modified](https://github.com/ess-dmsc/kafka-to-nexus/pull/659) the File Writer to ignore kafka broker addresses sent as part of pl72 "RunStart" messages. The File Writer will use its own internal configuration instead.

The flatbuffers definition does not set the field as mandatory, but a comment in the file does say that the file writer requires the field.
This PR modifies the comment to represent the changes performed in the File Writer.

### Issue

There is a [related discussion](https://github.com/ess-dmsc/streaming-data-types/issues/76) to decide if pl72 should be modified/superseded but a decision is not required to merge this PR, because the PR only modifies a documentation comment.

### Developer Checklist

- [X] If there are new schema in this PR I have added them to the list in README.md
- [X] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [X] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.


## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.

