### PR TITLE
Adding new schema se00, which will replace senv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and work with the flat buffers union data type in your root element.
 | ba57 | `ba57_run_info.fbs             ` | [OBSOLETE] Run start/stop information for Mantid [superseded by pl72]
 | df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid
 | senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.
-| se00 | `se00_data.fbs                 ` | Used for storing for waveforms from DG ADC readout system. Replaces _senv_.
+| se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_. 
 | NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions.
 | ADAr | `ADAr_area_detector_array.fbs  ` | Holds EPICS area detector array data (in a flatbuffer format).
 | mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ and work with the flat buffers union data type in your root element.
 | is84 | `is84_isis_events.fbs          ` | ISIS specific addition to event messages
 | ba57 | `ba57_run_info.fbs             ` | [OBSOLETE] Run start/stop information for Mantid [superseded by pl72]
 | df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid
-| senv | `senv_data.fbs                 ` | Used for storing for waveforms from DG ADC readout system.
+| senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.
+| se00 | `se00_data.fbs                 ` | Used for storing for waveforms from DG ADC readout system. Replaces _senv_.
 | NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions.
 | ADAr | `ADAr_area_detector_array.fbs  ` | Holds EPICS area detector array data (in a flatbuffer format).
 | mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ and work with the flat buffers union data type in your root element.
 | df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid
 | senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.
 | se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_. 
-| senv | `senv_data.fbs                 ` | Used for storing for waveforms from DG ADC readout system
 | NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions
 | ADAr | `ADAr_area_detector_array.fbs  ` | Holds EPICS area detector array data (in a flatbuffer format)
 | mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks

--- a/schemas/se00_data.fbs
+++ b/schemas/se00_data.fbs
@@ -29,17 +29,17 @@ union ValueUnion {
 }
 
 table SampleEnvironmentData {
-    Name: string (required);     // Name of the device/source of the data.
-    Channel: int;                // Can be used to store the ADC channel number. Should be set to -1 if not used.
-    PacketTimestamp: long;      // The timestamp (in nanoseconds since UNIX epoch) of the first sample in the value vector.
-    TimeDelta: double;           // Time in nanoseconds between samples. Available for "compression" of the schema. Should
+    name: string (required);     // Name of the device/source of the data.
+    channel: int;                // Can be used to store the ADC channel number. Should be set to -1 if not used.
+    packet_timestamp: long;      // The timestamp (in nanoseconds since UNIX epoch) of the first sample in the value vector.
+    time_delta: double;           // Time in nanoseconds between samples. Available for "compression" of the schema. Should
                                  // be set to <= 0 if not used.
-    TimestampLocation: Location; // Relevant when the delta time between two consecutive timestamps is long in comparison
+    timestamp_location: Location; // Relevant when the delta time between two consecutive timestamps is long in comparison
                                  // to the resolution of the timestamp. For example, when using oversampling.
                                  // middle or end of the samples that were summed to produce each oversampled sample.
-    Values: ValueUnion (required); // The sample values.
-    Timestamps: [long];         // OPTIONAL (nanosecond) timestamps of each individual sample.
-    MessageCounter: long;       // Monotonically increasing counter.
+    values: ValueUnion (required); // The sample values.
+    timestamps: [long];         // OPTIONAL (nanosecond) timestamps of each individual sample.
+    message_counter: long;       // Monotonically increasing counter.
 }
 
 root_type SampleEnvironmentData;

--- a/schemas/se00_data.fbs
+++ b/schemas/se00_data.fbs
@@ -1,7 +1,6 @@
 //Used to transmit fast sample environment data
-// NOTE: THIS SCHEMA HAS BEEN DEPRECATED
 
-file_identifier "senv";
+file_identifier "se00";
 
 enum Location : byte { Unknown = 0, Start, Middle, End }
 
@@ -13,6 +12,8 @@ table Int32Array    { value: [ int] (required);    }
 table UInt32Array   { value: [uint] (required);    }
 table Int64Array   { value: [ long] (required);   }
 table UInt64Array  { value: [ulong] (required);   }
+table DoubleArray { value: [double] (required);   }
+table FloatArray  { value: [float] (required);   }
 
 union ValueUnion {
     Int8Array,
@@ -22,7 +23,9 @@ union ValueUnion {
     Int32Array,
     UInt32Array,
     Int64Array,
-    UInt64Array
+    UInt64Array,
+    DoubleArray,
+    FloatArray
 }
 
 table SampleEnvironmentData {

--- a/schemas/se00_data.fbs
+++ b/schemas/se00_data.fbs
@@ -1,4 +1,4 @@
-//Used to transmit fast sample environment data
+//Used for storing arrays with optional timestamps, for example waveform data.
 
 file_identifier "se00";
 

--- a/schemas/se00_data.fbs
+++ b/schemas/se00_data.fbs
@@ -31,15 +31,15 @@ union ValueUnion {
 table SampleEnvironmentData {
     Name: string (required);     // Name of the device/source of the data.
     Channel: int;                // Can be used to store the ADC channel number. Should be set to -1 if not used.
-    PacketTimestamp: ulong;      // The timestamp (in nanoseconds since UNIX epoch) of the first sample in the value vector.
+    PacketTimestamp: long;      // The timestamp (in nanoseconds since UNIX epoch) of the first sample in the value vector.
     TimeDelta: double;           // Time in nanoseconds between samples. Available for "compression" of the schema. Should
                                  // be set to <= 0 if not used.
     TimestampLocation: Location; // Relevant when the delta time between two consecutive timestamps is long in comparison
                                  // to the resolution of the timestamp. For example, when using oversampling.
                                  // middle or end of the samples that were summed to produce each oversampled sample.
     Values: ValueUnion (required); // The sample values.
-    Timestamps: [ulong];         // OPTIONAL (nanosecond) timestamps of each individual sample.
-    MessageCounter: ulong;       // Monotonically increasing counter.
+    Timestamps: [long];         // OPTIONAL (nanosecond) timestamps of each individual sample.
+    MessageCounter: long;       // Monotonically increasing counter.
 }
 
 root_type SampleEnvironmentData;


### PR DESCRIPTION
Description of Work

The senv schema was deprecated, and a new schema, se00, was created to be able to handle arrays of floats and doubles, in addition to ints and uints.

Further work will be needed in the file writer, which can be followed here: https://jira.esss.lu.se/browse/ECDC-3171

Issue

Jira ticket: https://jira.esss.lu.se/browse/ECDC-3170

When trying to forward the PV YMIR-SETS:SE-BADC-001:VALUE, it was noticed that the senv schema could not handle floats and doubles.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R, Mark K and Jack H have given their explicit approval in the comments section.


