### PR TITLE
Updated ep01_epics_connection.fbs documentation only

### DIFF
--- a/schemas/ep01_epics_connection.fbs
+++ b/schemas/ep01_epics_connection.fbs
@@ -7,10 +7,10 @@ enum ConnectionInfo: short {
   NEVER_CONNECTED,      // Universal
   CONNECTED,            // Universal
   DISCONNECTED,         // Universal
-  DESTROYED,            // CA (not verified)
-  CANCELLED,            // pvAccess
-  FINISHED,             // pvAccess
-  REMOTE_ERROR,         // pvAccess
+  DESTROYED,            // Previously was used as a catch-all state (remove in next version of this schema?)
+  CANCELLED,            // pvAccess - client cancelled the subscription
+  FINISHED,             // pvAccess - the server has indicated it will send no more messages
+  REMOTE_ERROR,         // pvAccess - the server has sent an "exception" to the client
 }
 
 table EpicsPVConnectionInfo {

--- a/schemas/ep01_epics_connection.fbs
+++ b/schemas/ep01_epics_connection.fbs
@@ -7,7 +7,7 @@ enum ConnectionInfo: short {
   NEVER_CONNECTED,      // Universal
   CONNECTED,            // Universal
   DISCONNECTED,         // Universal
-  DESTROYED,            // Previously was used as a catch-all state (remove in next version of this schema?)
+  DESTROYED,            // Was used as a catch-all state in ep00 (remove in next version of this schema?)
   CANCELLED,            // pvAccess - client cancelled the subscription
   FINISHED,             // pvAccess - the server has indicated it will send no more messages
   REMOTE_ERROR,         // pvAccess - the server has sent an "exception" to the client


### PR DESCRIPTION
Clarified what the various PVA connection types mean based on the EPICS docs. I wonder, in hindsight, if the ConnectionInfo should have stayed generic like in ep00?