### PR TITLE
f144 schema fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The file identifiers (also called "schema id") must be unique on the network. Wh
 The `root_type` should include the schema version number. For example, the f144 schema has
 the `root_type`:
 ```
-root_type LogData144;
+root_type f144_LogData;
 ```
 
 Table of schema file identifiers follows later in this README. Please add your own (new schema) with file identifier to that table.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ file_identifier = "abcd";
 ```
 
 The file identifiers (also called "schema id") must be unique on the network. When creating a new schema generate a random one using [this webpage](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new).
-The `root_type` should include the schema version number. For example the f144 schema has
+The `root_type` should include the schema version number. For example, the f144 schema has
 the `root_type`:
 ```
 root_type LogData144;

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ file_identifier = "abcd";
 ```
 
 The file identifiers (also called "schema id") must be unique on the network. When creating a new schema generate a random one using [this webpage](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new).
+The `root_type` should include the schema version number. For example the f144 schema has
+the `root_type`:
+```
+root_type LogData144;
+```
 
 Table of schema file identifiers follows later in this README. Please add your own (new schema) with file identifier to that table.
 

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -53,4 +53,4 @@ table f144_LogData {
   value: Value (required);             // May be scalar or array
 }
 
-root_type LogData144;
+root_type f144_LogData;

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -47,10 +47,10 @@ union Value {
 	ArrayDouble,
 }
 
-table LogDataf144 {
+table LogData144 {
   source_name: string (required);      // EPICS PV name
   timestamp: long;                     // Nanoseconds since UNIX epoch
   value: Value (required);             // May be scalar or array
 }
 
-root_type LogDataf144;
+root_type LogData144;

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -47,7 +47,7 @@ union Value {
 	ArrayDouble,
 }
 
-table LogData {
+table LogDataf144 {
   source_name: string (required);      // EPICS PV name
   timestamp: long;                     // Nanoseconds since UNIX epoch
   value: Value (required);             // May be scalar or array

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -53,4 +53,4 @@ table LogData {
   value: Value (required);             // May be scalar or array
 }
 
-root_type LogData;
+root_type LogDataf144;

--- a/schemas/f144_logdata.fbs
+++ b/schemas/f144_logdata.fbs
@@ -47,7 +47,7 @@ union Value {
 	ArrayDouble,
 }
 
-table LogData144 {
+table f144_LogData {
   source_name: string (required);      // EPICS PV name
   timestamp: long;                     // Nanoseconds since UNIX epoch
   value: Value (required);             // May be scalar or array


### PR DESCRIPTION
### Description of Work

The root-type clash betwen f142 and f144 schemas was causing problems for verification, serialization and deserialization.

### Issue

Associated ticket: https://jira.esss.lu.se/browse/ECDC-3200

## Approval Criteria

This PR should not be merged until Tobias R and Mark K have given their explicit approval in the comments section.


