### PR TITLE
Doc: Fix mention to random identifiers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ schema definition file as:
 file_identifier = "abcd";
 ```
 
-The file identifiers (also called "schema id") must be unique on the network. When creating a new schema generate a random one using [this webpage](https://www.random.org/strings/?num=1&len=4&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new).
+The file identifiers (also called "schema id") must be unique on the network.
 The `root_type` should include the schema version number. For example, the f144 schema has
 the `root_type`:
 ```
 root_type f144_LogData;
 ```
 
-Table of schema file identifiers follows later in this README. Please add your own (new schema) with file identifier to that table.
+The naming convention for new identifiers and a table of existing identifiers follows later in this README.
+Please add your own (new schema) with file identifier to that table.
 
 
 ## Backwards compatibility


### PR DESCRIPTION
### Description of Work

The README file contains a reference to the previous schema naming convention that used random strings.



