### PR TITLE
Update pl72_run_start to document start_time as Required for the Filewriter

### DIFF
--- a/schemas/pl72_run_start.fbs
+++ b/schemas/pl72_run_start.fbs
@@ -12,7 +12,7 @@ include "df12_det_spec_map.fbs";
 file_identifier "pl72";
 
 table RunStart {                                     //  *Mantid*    // *File Writer* // *Description*
-    start_time : uint64;                             //  Required    //  Optional     // milliseconds since Unix epoch (1 Jan 1970)
+    start_time : uint64;                             //  Required    //  Required     // milliseconds since Unix epoch (1 Jan 1970)
     stop_time : uint64;                              //  Unused      //  Optional     // milliseconds since Unix epoch (1 Jan 1970), optional, can send a RunStop instead
     run_name : string;                               //  Required    //  Unused       // Name for the run, used as workspace name by Mantid
     instrument_name : string;                        //  Required    //  Unused       // Name of the instrument, only required by Mantid


### PR DESCRIPTION
### Description of Work

We have observed that the File Writer occasionally misses some `job_stop` messages if they come very quickly after a `job_start` message. More details [here](https://jira.esss.lu.se/browse/ECDC-3237).

To implement a consistent start job process in which the File Writer starts listening for commands precisely from the `start_time` of the pl72 start message, we propose to change the documentation text of this schema to indicate that `start_time` is now Required.

Note that the change is only in the documentation, not in the schema specification.



### Developer Checklist

- [X] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.


## Approval Criteria

This PR should not be merged until Tobias R and Mark K have given their explicit approval in the comments section.


