### PR TITLE
Add hs02 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ and work with the flat buffers union data type in your root element.
 | mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks
 | ns10 | `ns10_cache_entry.fbs          ` | NICOS cache entry
 | ns11 | `ns11_typed_cache_entry.fbs    ` | NICOS cache entry with typed data
-| hs00 | `hs00_event_histogram.fbs      ` | Event histogram stored in n dim array
-| hs01 | `hs01_event_histogram.fbs      ` | Event histogram stored in n dim array
+| hs00 | `hs00_event_histogram.fbs      ` | Event histogram stored in n dim array (uses unsigned integers)
+| hs02 | `hs02_event_histogram.fbs      ` | Event histogram stored in n dim array
 | dtdb | `dtdb_adc_pulse_debug.fbs      ` | Debug fields that can be added to the ev42 schema
 | ep00 | `ep00_epics_connection_info.fbs` | (DEPRECATED) Status of the EPICS connection
 | ep01 | `ep01_epics_connection.fbs  `    | Status or event of EPICS connection. Replaces _ep00_

--- a/schemas/hs02_event_histogram.fbs
+++ b/schemas/hs02_event_histogram.fbs
@@ -29,7 +29,7 @@ table DimensionMetaData {
 
 // Represents a n-dimensional histogram
 // Subsets of histogram are also supported
-table EventHistogram {
+table hs02_EventHistogram {
     source_name: string;                // Source name
     timestamp: long;                    // Timestamp (in ns, after unix epoch)
     dim_metadata: [DimensionMetaData];  // Meta data for each dimension

--- a/schemas/hs02_event_histogram.fbs
+++ b/schemas/hs02_event_histogram.fbs
@@ -21,8 +21,8 @@ union Array {
 
 // Meta information for one dimension
 table DimensionMetaData {
-    length: int (required);    // Length of the full histogram along this dimension
     label: string (required);  // Label
+    length: int;               // Length of the full histogram along this dimension
     unit: string;              // Unit
     bin_boundaries: Array;     // Boundary information (should be of length: DimensionMetaData.length+1)
 }

--- a/schemas/hs02_event_histogram.fbs
+++ b/schemas/hs02_event_histogram.fbs
@@ -21,24 +21,24 @@ union Array {
 
 // Meta information for one dimension
 table DimensionMetaData {
-    length: int;            // Length of the full histogram along this dimension
-    unit: string;           // Unit
-    label: string;          // Label
-    bin_boundaries: Array;  // Boundary information (should be of length: DimensionMetaData.length+1)
+    length: int (required);    // Length of the full histogram along this dimension
+    label: string (required);  // Label
+    unit: string;              // Unit
+    bin_boundaries: Array;     // Boundary information (should be of length: DimensionMetaData.length+1)
 }
 
 // Represents a n-dimensional histogram
 // Subsets of histogram are also supported
 table hs02_EventHistogram {
-    source_name: string;                // Source name
-    timestamp: long;                    // Timestamp (in ns, after unix epoch)
-    dim_metadata: [DimensionMetaData];  // Meta data for each dimension
-    last_metadata_timestamp: long;      // Timestamp (ns, after unix epoch) when the last metadata information was written
-    current_shape: [int] (required);    // Shape of the current data in each dimension
-    offset: [int];                      // Offset giving the starting index in each dimension
-    data: Array;                        // Data represented in RowMajor order (C Style), filled with 0 if missing
-    errors: Array;                      // Errors in calculation of histogram data (same size as data)
-    info: string;                       // Additional information (Integrated/Processed)
+    source_name: string (required);                // Source name
+    current_shape: [int] (required);               // Shape of the current data in each dimension
+    dim_metadata: [DimensionMetaData];             // Meta data for each dimension
+    timestamp: long;                               // Timestamp (in ns, after unix epoch)
+    data: Array;                                   // Data represented in RowMajor order (C Style), filled with 0 if missing
+    errors: Array;                                 // Errors in calculation of histogram data (same size as data)
+    offset: [int];                                 // Offset giving the starting index in each dimension
+    last_metadata_timestamp: long;                 // Timestamp (ns, after unix epoch) when the last metadata information was written
+    info: string;                                  // Additional information (Integrated/Processed)
 }
 
 // The "current_shape" and "offset" fields can be used to define a slice of a 

--- a/schemas/hs02_event_histogram.fbs
+++ b/schemas/hs02_event_histogram.fbs
@@ -1,0 +1,53 @@
+// General schema for histogram
+
+file_identifier "hs02";
+
+table ArrayInt8   { value: [int8];   }
+table ArrayInt16  { value: [int16];  }
+table ArrayInt32  { value: [int32];  }
+table ArrayInt64  { value: [int64];  }
+table ArrayFloat  { value: [float];  }
+table ArrayDouble { value: [double]; }
+
+// Union of allowed data types for the arrays
+union Array {
+    ArrayInt8,
+    ArrayInt16,
+    ArrayInt32,
+    ArrayInt64,
+    ArrayFloat,
+    ArrayDouble,
+}
+
+// Meta information for one dimension
+table DimensionMetaData {
+    length: int;            // Length of the full histogram along this dimension
+    unit: string;           // Unit
+    label: string;          // Label
+    bin_boundaries: Array;  // Boundary information (should be of length: DimensionMetaData.length+1)
+}
+
+// Represents a n-dimensional histogram
+// Subsets of histogram are also supported
+table EventHistogram {
+    source_name: string;                // Source name
+    timestamp: long;                    // Timestamp (in ns, after unix epoch)
+    dim_metadata: [DimensionMetaData];  // Meta data for each dimension
+    last_metadata_timestamp: long;      // Timestamp (ns, after unix epoch) when the last metadata information was written
+    current_shape: [int] (required);    // Shape of the current data in each dimension
+    offset: [int];                      // Offset giving the starting index in each dimension
+    data: Array;                        // Data represented in RowMajor order (C Style), filled with 0 if missing
+    errors: Array;                      // Errors in calculation of histogram data (same size as data)
+    info: string;                       // Additional information (Integrated/Processed)
+}
+
+// The "current_shape" and "offset" fields can be used to define a slice of a 
+// larger histogram. This allows breaking a large histogram into multiple messages.
+// For example the dim_metadata could look like this:
+// dim_metadata=[DimensionMetaData(label="x", length=10, ...), DimensionMetaData(label="y", length=10, ...)]
+// and each row could be sent as a separate message by using:
+// current_shape=[10, 1] and offset=[0, 0] in the 1st message
+// current_shape=[10, 1] and offset=[0, 1] in the 2nd message
+// and so on.
+
+root_type hs02_EventHistogram;


### PR DESCRIPTION
### Description of Work

Add a hs02 schema with the following fixes with respect to hs01:

- Fix duplicated root_type used by hs01
- Support integers of 8, 16, 32 and 64 bits instead of 32/64 bits only
- Fix source_name naming as per guidelines in this repo: https://github.com/ess-dmsc/streaming-data-types
- Make the following fields mandatory:
  - `EventHistogram.source_name`
  - `DimensionMetaData.label`

QUESTION: Should dim_metadata field be mandatory too?

### Developer Checklist

- [X] If there are new schema in this PR I have added them to the list in README.md
- [X] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [X] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R and Mark K have given their explicit approval in the comments section.


