### PR TITLE
[Add] hm00 flatbuffer specification for N-D histograms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Tries to locate flatc with find_program.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 project(streaming-data-types)
 
 if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
@@ -20,6 +20,8 @@ set(schemas_subdir "schemas")
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${schemas_subdir}")
 file(GLOB_RECURSE flatbuffers_schemata RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/schemas" "schemas/*.fbs")
 
+set(flatbuffers_generated_python "")
+
 foreach (f0 ${flatbuffers_schemata})
 	string(REGEX REPLACE "\\.fbs$" "" s0 ${f0})
 	set(fbs "${schemas_subdir}/${s0}.fbs")
@@ -32,6 +34,18 @@ foreach (f0 ${flatbuffers_schemata})
 		COMMENT "Process ${fbs} using ${FLATC}"
 	)
 	list(APPEND flatbuffers_generated_headers "${CMAKE_CURRENT_BINARY_DIR}/${fbh}")
+
+	string(REGEX REPLACE "\\.fbs$" ".py" fbp ${f0})
+	add_custom_command(
+		OUTPUT "${fbp}"
+		COMMAND ${FLATC} --python --gen-mutable --gen-name-strings --scoped-enums "${CMAKE_CURRENT_SOURCE_DIR}/${fbs}"
+		DEPENDS "${fbs}"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${schemas_subdir}"
+		COMMENT "Process ${fbs} to ${fbp} using ${FLATC}"
+	)
+	list(APPEND flatbuffers_generated_python "${CMAKE_CURRENT_BINARY_DIR}/${fbp}")
 endforeach()
 
 add_custom_target(flatbuffers_generate ALL DEPENDS ${flatbuffers_generated_headers})
+
+add_custom_target(python ALL DEPENDS ${flatbuffers_generated_python})

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ and work with the flat buffers union data type in your root element.
 | ns11 | `ns11_typed_cache_entry.fbs    ` | NICOS cache entry with typed data
 | hs00 | `hs00_event_histogram.fbs      ` | Event histogram stored in n dim array
 | hs01 | `hs01_event_histogram.fbs      ` | Event histogram stored in n dim array
+| hm00 | `hm00_histograms.fbs           ` | Time series histograms. 
 | dtdb | `dtdb_adc_pulse_debug.fbs      ` | Debug fields that can be added to the ev42 schema
 | ep00 | `ep00_epics_connection_info.fbs` | (DEPRECATED) Status of the EPICS connection
 | ep01 | `ep01_epics_connection.fbs  `    | Status or event of EPICS connection. Replaces _ep00_

--- a/schemas/da00_dataarray.fbs
+++ b/schemas/da00_dataarray.fbs
@@ -1,0 +1,35 @@
+
+// A flatbuffer schema for holding histogram data or EPICS area detector updates
+// A merger of hs00/hs01 and ADAr aimed at compatibility with scipp DataArrays
+
+file_identifier "da00";
+
+enum DType: byte {int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64, c_string}
+
+table Attribute {
+    name: string (required);   // Name of attribute
+    description: string;       // Description of attribute
+    source: string;            // EPICS PV name or DRV_INFO string of attribute
+    data_type: DType;          // The type of the data (value) in this attribute
+    data: [ubyte] (required);  // The data/value of the attribute
+}
+
+table Variable {
+    name: string (required);       // What this data represents: e.g., 'data', 'errors', '{axis_name}'
+    unit: string;                  // (optional) unit name for the represented data
+    label: string;                 // (optional) label describing the data
+    data_type: DType;              // data type for the stored data in the array
+    dims: [string] (required);     // The ordered names of the axes of this data
+    shape: [long] (required);      // Shape of the multi-dimensional array
+    data: [ubyte] (required);      // C-ordered flat array interpreted as unsigned 8-bit integers
+}
+
+table da00_DataArray {
+    source_name: string (required); // Source name of array
+    id: int;                        // Unique id to this particular NDArray
+    timestamp: ulong;               // Timestamp in nanoseconds since UNIX epoch
+    data: [Variable] (required);    // The data in one or more DataArray
+    attributes: [Attribute];        // Extra metadata about the array
+}
+
+root_type da00_DataArray;

--- a/schemas/hm00_histograms.fbs
+++ b/schemas/hm00_histograms.fbs
@@ -1,0 +1,42 @@
+
+// A flatbuffer schema for holding histogram data or EPICS area detector updates
+// A merger of hs00/hs01 and ADAr
+
+file_identifier "hm00";
+
+enum DType: byte {int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64, c_string}
+
+table Attribute {
+    name: string (required);   // Name of attribute
+    description: string;       // Description of attribute
+    source: string;            // EPICS PV name or DRV_INFO string of attribute
+    data_type: DType;          // The type of the data (value) in this attribute
+    data: [ubyte] (required);  // The data/value of the attribute
+}
+
+table BinBoundaryData {
+    name: string (required); // The axis name
+    unit: string;            // A unit in which the boundaries are expressed
+    label: string;           // A label describing the axis
+    data_type: DType;        // The type of the boundary values
+    data: [ubyte];           // The bin boundaries -- there must be one more boundary than bin.
+}
+
+table HistogramData {
+    unit: string;                  // (optional) unit name for the represented data
+    data_type: DType;              // data type for the stored data in the array
+    shape: [long] (required);      // Shape of the multi-dimensional array
+    data: [ubyte] (required);      // C-ordered flat array interpreted as unsigned 8-bit integers
+}
+
+table hm00_Array {
+    source_name: string (required); // Source name of array
+    id: int;                        // Unique id to this particular NDArray
+    timestamp: ulong;               // Timestamp in nanoseconds since UNIX epoch
+    dimensions: [BinBoundaryData];  // Dimensions of the array
+    data: HistogramData;            // Elements in the array
+    errors: HistogramData;          // Uncertainty in the array elements
+    attributes: [Attribute];        // Extra metadata about the array
+}
+
+root_type hm00_Array;


### PR DESCRIPTION
### Description of Work
As an alternative to the hs02 introduced in #90: 
Add features from hs00/hs01 into a structure akin to ADAr. The histogram itself is moved into a sub-table so that it can be used for both a required data histogram and optional errors histogram.

Optional bin-boundary specifications are added. The attributes from ADAr is ported over.

By moving repeated object-types into tables, dataclasses can be used in Python to more-easily serialise and deserialise the flatbuffer.

(A python implentation of the serialiser and deserialiser for hm01 has been written, with inspiration taken from ADAr)


### Known problems

I've inadvertently introduced changes to the `CMakeLists.txt` file. I can revert that file to the master version before any potential merge occurs.
The changes I made were aimed at automatically producing Python flatbuffer implementations, which I think is a good thing (even if my results leave something to be desired).

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R and Mark K have given their explicit approval in the comments section.


