### PR TITLE
Add da00 dataarray schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,40 +56,41 @@ and work with the flat buffers union data type in your root element.
 
 
 ## Schema ids
-| ID   | File name                        | Description                                                          |
-|------|----------------------------------|----------------------------------------------------------------------|
-| f140 | `f140_general.fbs              ` | [OBSOLETE] Can encode an arbitrary EPICS PV
-| f141 | `f141_ntarraydouble.fbs        ` | [OBSOLETE] A simple array of double, testing file writing
-| f142 | `f142_logdata.fbs              ` | For log data, for example forwarded EPICS PV update [superseded by f144]
-| f143 | `f143_structure.fbs            ` | [OBSOLETE] Arbitrary nested data
-| f144 | `f144_logdata.fbs              ` | Controls related log data, typically from EPICS or NICOS
-| ev42 | `ev42_events.fbs               ` | Multi-institution neutron event data for a single pulse
-| ev43 | `ev43_events.fbs               ` | Multi-institution neutron event data from multiple pulses
-| ev44 | `ev44_events.fbs               ` | Multi-institution neutron event data for both single and multiple pulses
-| is84 | `is84_isis_events.fbs          ` | ISIS specific addition to event messages
-| ba57 | `ba57_run_info.fbs             ` | [OBSOLETE] Run start/stop information for Mantid [superseded by pl72]
-| df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid
-| senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.
-| se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_. 
-| NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions
-| ADAr | `ADAr_area_detector_array.fbs  ` | Holds EPICS area detector array data (in a flatbuffer format)
-| mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks
-| ns10 | `ns10_cache_entry.fbs          ` | NICOS cache entry
-| ns11 | `ns11_typed_cache_entry.fbs    ` | NICOS cache entry with typed data
-| hs00 | `hs00_event_histogram.fbs      ` | Event histogram stored in n dim array
-| hs01 | `hs01_event_histogram.fbs      ` | Event histogram stored in n dim array
-| dtdb | `dtdb_adc_pulse_debug.fbs      ` | Debug fields that can be added to the ev42 schema
-| ep00 | `ep00_epics_connection_info.fbs` | (DEPRECATED) Status of the EPICS connection
-| ep01 | `ep01_epics_connection.fbs  `    | Status or event of EPICS connection. Replaces _ep00_
-| json | `json_json.fbs                 ` | Carries a JSON payload
-| tdct | `tdct_timestamps.fbs           ` | Timestamps from a device (e.g. a chopper)
-| pl72 | `pl72_run_start.fbs            ` | File writing, run start message for file writer and Mantid
-| 6s4t | `6s4t_run_stop.fbs             ` | File writing, run stop message for file writer and Mantid
-| answ | `answ_action_response.fbs      ` | Holds the result of a command to the filewriter
-| wrdn | `wrdn_finished_writing.fbs     ` | Message from the filewriter when it is done writing a file
-| x5f2 | `x5f2_status.fbs               ` | Status update and heartbeat message for any software
-| rf5k | `rf5k_forwarder_config.fbs     ` | Configuration update for Forwarder
-| al00 | `al00_alarm.fbs                ` | Generic alarm schema for EPICS, NICOS, etc.
+| ID   | File name                        | Description                                                                                   |
+|------|----------------------------------|-----------------------------------------------------------------------------------------------|
+| f140 | `f140_general.fbs              ` | [OBSOLETE] Can encode an arbitrary EPICS PV                                                   |
+| f141 | `f141_ntarraydouble.fbs        ` | [OBSOLETE] A simple array of double, testing file writing                                     |
+| f142 | `f142_logdata.fbs              ` | For log data, for example forwarded EPICS PV update [superseded by f144]                      |
+| f143 | `f143_structure.fbs            ` | [OBSOLETE] Arbitrary nested data                                                              |
+| f144 | `f144_logdata.fbs              ` | Controls related log data, typically from EPICS or NICOS                                      |
+| ev42 | `ev42_events.fbs               ` | Multi-institution neutron event data for a single pulse                                       |
+| ev43 | `ev43_events.fbs               ` | Multi-institution neutron event data from multiple pulses                                     |
+| ev44 | `ev44_events.fbs               ` | Multi-institution neutron event data for both single and multiple pulses                      |
+| is84 | `is84_isis_events.fbs          ` | ISIS specific addition to event messages                                                      |
+| ba57 | `ba57_run_info.fbs             ` | [OBSOLETE] Run start/stop information for Mantid [superseded by pl72]                         |
+| df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid                                                              |
+| senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.                       |
+| se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_. | 
+| NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions                                      |
+| ADAr | `ADAr_area_detector_array.fbs  ` | Holds EPICS area detector array data (in a flatbuffer format)                                 |
+| mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks                          | 
+| ns10 | `ns10_cache_entry.fbs          ` | NICOS cache entry                                                                             |
+| ns11 | `ns11_typed_cache_entry.fbs    ` | NICOS cache entry with typed data                                                             |
+| hs00 | `hs00_event_histogram.fbs      ` | Event histogram stored in n dim array                                                         |
+| hs01 | `hs01_event_histogram.fbs      ` | Event histogram stored in n dim array                                                         |
+| dtdb | `dtdb_adc_pulse_debug.fbs      ` | Debug fields that can be added to the ev42 schema                                             |
+| ep00 | `ep00_epics_connection_info.fbs` | (DEPRECATED) Status of the EPICS connection                                                   |
+| ep01 | `ep01_epics_connection.fbs  `    | Status or event of EPICS connection. Replaces _ep00_                                          |
+| json | `json_json.fbs                 ` | Carries a JSON payload                                                                        |
+| tdct | `tdct_timestamps.fbs           ` | Timestamps from a device (e.g. a chopper)                                                     |
+| pl72 | `pl72_run_start.fbs            ` | File writing, run start message for file writer and Mantid                                    |
+| 6s4t | `6s4t_run_stop.fbs             ` | File writing, run stop message for file writer and Mantid                                     |
+| answ | `answ_action_response.fbs      ` | Holds the result of a command to the filewriter                                               |
+| wrdn | `wrdn_finished_writing.fbs     ` | Message from the filewriter when it is done writing a file                                    |
+| x5f2 | `x5f2_status.fbs               ` | Status update and heartbeat message for any software                                          |
+| rf5k | `rf5k_forwarder_config.fbs     ` | Configuration update for Forwarder                                                            |
+| al00 | `al00_alarm.fbs                ` | Generic alarm schema for EPICS, NICOS, etc.                                                   |
+| da00 | `da00_dataarray.fbs            ` | Pseudo-scipp DataArray with time-dependent and constant Variables                             |
 
 
 ## Useful information:

--- a/schemas/da00_dataarray.fbs
+++ b/schemas/da00_dataarray.fbs
@@ -12,7 +12,7 @@ table da00_Variable {
     label: string;             // (optional) label describing the data
     source: string;            // (optional) EPICS PV name, DRV_INFO string, etc. [expected for attributes]
     data_type: da00_dtype;     // data type for the stored data in the array
-    dims: [string] (required); // The ordered names of the axes of this data
+    axes: [string] (required); // The ordered names of the axes of this data
     shape: [long] (required);  // Shape of the multi-dimensional array
     data: [ubyte] (required);  // C-ordered flat array interpreted as unsigned 8-bit integers
 }

--- a/schemas/da00_dataarray.fbs
+++ b/schemas/da00_dataarray.fbs
@@ -1,0 +1,28 @@
+
+// A flatbuffer schema for holding histogram data or EPICS area detector updates
+// A merger of hs00/hs01 and ADAr aimed at compatibility with scipp DataArrays
+
+file_identifier "da00";
+
+enum da00_dtype: byte {none, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64, c_string}
+
+table da00_Variable {
+    name: string (required);   // What this data represents: e.g., 'data', 'errors', '{axis_name}'
+    unit: string;              // (optional) unit name for the represented data [expected for datasets]
+    label: string;             // (optional) label describing the data
+    source: string;            // (optional) EPICS PV name, DRV_INFO string, etc. [expected for attributes]
+    data_type: da00_dtype;     // data type for the stored data in the array
+    dims: [string] (required); // The ordered names of the axes of this data
+    shape: [long] (required);  // Shape of the multi-dimensional array
+    data: [ubyte] (required);  // C-ordered flat array interpreted as unsigned 8-bit integers
+}
+
+table da00_DataArray {
+    source_name: string (required);// Source name of array
+    timestamp: ulong;              // Timestamp in nanoseconds since UNIX epoch
+    variables: [da00_Variable];    // Variable dataset objects which could contain different data with every message
+    constants: [da00_Variable];    // Variable dataset objects which are unchanged from message-to-message
+    attributes: [da00_Variable];   // Variable attribute objects
+}
+
+root_type da00_DataArray;

--- a/schemas/da00_dataarray.fbs
+++ b/schemas/da00_dataarray.fbs
@@ -12,14 +12,14 @@ table da00_Variable {
     label: string;             // (optional) label describing the data
     source: string;            // (optional) EPICS PV name, DRV_INFO string, etc. [expected for attributes]
     data_type: da00_dtype;     // data type for the stored data in the array
-    axes: [string] (required); // The ordered names of the axes of this data
+    axes: [string];            // (optional) The ordered names of the axes of this data [expected if meaningful]
     shape: [long] (required);  // Shape of the multi-dimensional array
     data: [ubyte] (required);  // C-ordered flat array interpreted as unsigned 8-bit integers
 }
 
 table da00_DataArray {
     source_name: string (required);   // Source name of array
-    timestamp: ulong;                 // Timestamp in nanoseconds since UNIX epoch
+    timestamp: long;                  // Timestamp in nanoseconds since UNIX epoch
     data: [da00_Variable] (required); // One or more dataset/attribute
 }
 

--- a/schemas/da00_dataarray.fbs
+++ b/schemas/da00_dataarray.fbs
@@ -18,11 +18,9 @@ table da00_Variable {
 }
 
 table da00_DataArray {
-    source_name: string (required);// Source name of array
-    timestamp: ulong;              // Timestamp in nanoseconds since UNIX epoch
-    variables: [da00_Variable];    // Variable dataset objects which could contain different data with every message
-    constants: [da00_Variable];    // Variable dataset objects which are unchanged from message-to-message
-    attributes: [da00_Variable];   // Variable attribute objects
+    source_name: string (required);   // Source name of array
+    timestamp: ulong;                 // Timestamp in nanoseconds since UNIX epoch
+    data: [da00_Variable] (required); // One or more dataset/attribute
 }
 
 root_type da00_DataArray;


### PR DESCRIPTION
### Description of Work
As an alternative to the hs02 introduced in #90 (and supplanting #91 as the correction to #92):

Add features from hs00/hs01 into a structure akin to ADAr. The histogram itself is moved into a sub-table that can be used for arbitrary time-dependent, time-independent, or group-level attribute data.

(A python implementation of the serialiser and deserialiser for da00 has been written, with inspiration taken from ADAr -- stored at https://github.com/g5t/python-streaming-data-types/tree/add-da00-dataarray)
### Issue
- The enumerated `data_type` may be overly complicated, but is working in conjunction with both the Python (de)serialiser and the file-writer module drafts.
- The timestamp is an unsigned integer, which should probably be changed to signed; but requires modifications in both other drafts too.

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until Tobias R and Mark K have given their explicit approval in the comments section.


