### PR TITLE
Update ev44_events.fbs documentation comments

### DIFF
--- a/schemas/ev44_events.fbs
+++ b/schemas/ev44_events.fbs
@@ -9,8 +9,8 @@ table Event44Message {
                                                 // If pulse times are available in the aquisition system, this field holds
                                                 // those timestamps. Holds wall time otherwise.
     reference_time_index : [int] (required);    // Index into the time_of_flight array for the start of the neutron events linked
-                                                // to the corresponding pulse/reference time. If time_of_flight is empty, the convention
-                                                // is to use "-1" as indices here. reference_time_index and reference_time are the same length.
+                                                // to the corresponding pulse/reference time.
+                                                // reference_time_index and reference_time are the same length.
     time_of_flight : [int];                     // Nanoseconds
                                                 // Time of flight for each event if pulse time is available. If not, a
                                                 // (positive) offset from the wall time stored in the `reference_time`.


### PR DESCRIPTION
### Description of Work

We extend the ev44 documentation comments to clarify some ambiguous aspects of the schema. In particular:

1. ~~We document the convention of using `-1` as indices inside `reference_time_index` anytime pulses are being sent, but `time_of_flight` is empty.~~
    -  ~~Background: These indices point to the appropriate element inside `time_of_flight`, so if `time_of_flight` is an empty array any non-negative value would point to a non-existent element. We convene that `-1` should be used in this case.~~
    - UPDATE: we remove this comment, as it contravenes the current semantics used by ANSTO, and we do not use this at the moment at ESS.

1. Since `time_of_flight` and `pixel_id` are non-required fields, we document that `time_of_flight` must always be present if events are being communicated in the message, whereas `pixel_id` is indeed optional if pixel IDs are implicit. This removes the current ambiguity in the schema, as it establishes the following semantics:
    - If both `time_of_flight` and `pixel_id` are empty: no events are being sent, only pulse times. In this case `reference_time_index` should include a index value of `-1`  for each pulse. (Note that the "event formation unit" does not currently send pulses without events, so this case may not be common)
    - If `time_of_flight` if present but `pixel_id` is empty: Events are being sent, but the pixel ID is implicit (e.g. a single-pixel beam monitor).
    - If `time_of_flight` if empty but `pixel_id` is present: Invalid. `time_of_flight` must be present if events are being sent.
    - If both `time_of_flight` and `pixel_id` are present: The common case where events are being sent with both `time_of_flight` and `pixel_id` information.

### Issue

The ev44 schema supports sending pulse times but leaving empty the array of events.
This is expected to be either because:

-  The pixel_id and time_of_flight are implicit. For example a beam monitor with a single pixel.
   - In this case, `time_of_flight` will be populated, but `pixel_id` may be empty.
-  The hardware has detected no events, but we still want to push the pulse_time to Kafka as a form of "heart beat".
    - This is currently not used by the "event formation unit", but the ev44 schema seems to support it by allowing empty  `time_of_flight` and `pixel_id` fields.

In the context of the file-writer, the ev44 module is focused on writing NXevent_data groups, where it makes little sense to add pulse_times where no events were recorded, but the current ev44 schema and documentation does not fully specify these corner cases.

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.



