### PR TITLE
adding new schema fc00, forwarder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ and work with the flat buffers union data type in your root element.
 | ev42 | `ev42_events.fbs               ` | Multi-institution neutron event data for a single pulse                                       |
 | ev43 | `ev43_events.fbs               ` | Multi-institution neutron event data from multiple pulses                                     |
 | ev44 | `ev44_events.fbs               ` | Multi-institution neutron event data for both single and multiple pulses                      |
-| ar51 | `ar51_readout_data.fbs         ` | Streaming raw ESS detector readout data
+| ar51 | `ar51_readout_data.fbs         ` | Streaming raw ESS detector readout data                                                       |
 | is84 | `is84_isis_events.fbs          ` | ISIS specific addition to event messages                                                      |
 | ba57 | `ba57_run_info.fbs             ` | [OBSOLETE] Run start/stop information for Mantid [superseded by pl72]                         |
 | df12 | `df12_det_spec_map.fbs         ` | Detector-spectrum map for Mantid                                                              |
 | senv | `senv_data.fbs                 ` | (DEPRECATED) Used for storing for waveforms from DG ADC readout system.                       |
-| se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_.| 
+| se00 | `se00_data.fbs                 ` | Used for storing arrays with optional timestamps, for example waveform data. Replaces _senv_. | 
 | NDAr | `NDAr_NDArray_schema.fbs       ` | (DEPRECATED) Holds binary blob of data with n dimensions                                      |
-| ADAr | `ADAr_area_detector_array.fbs  ` | (DEPRECATED) EPICS area detector array data [superseded by ad00]
-| ad00 | `ad00_area_detector_array.fbs  ` | EPICS area detector array data
+| ADAr | `ADAr_area_detector_array.fbs  ` | (DEPRECATED) EPICS area detector array data [superseded by ad00]                              |
+| ad00 | `ad00_area_detector_array.fbs  ` | EPICS area detector array data                                                                |
 | mo01 | `mo01_nmx.fbs                  ` | Daquiri monitor data: pre-binned histograms, raw hits and NMX tracks                          | 
 | ns10 | `ns10_cache_entry.fbs          ` | NICOS cache entry                                                                             |
 | ns11 | `ns11_typed_cache_entry.fbs    ` | NICOS cache entry with typed data                                                             |
@@ -90,7 +90,8 @@ and work with the flat buffers union data type in your root element.
 | answ | `answ_action_response.fbs      ` | Holds the result of a command to the filewriter                                               |
 | wrdn | `wrdn_finished_writing.fbs     ` | Message from the filewriter when it is done writing a file                                    |
 | x5f2 | `x5f2_status.fbs               ` | Status update and heartbeat message for any software                                          |
-| rf5k | `rf5k_forwarder_config.fbs     ` | Configuration update for Forwarder                                                            |
+| rf5k | `rf5k_forwarder_config.fbs     ` | (DEPRECATED) Configuration update for Forwarder [superseded by fc00]                          |
+| fc00 | `fc00_forwarder_config.fbs     ` | Configuration update for Forwarder                                                            |
 | al00 | `al00_alarm.fbs                ` | Generic alarm schema for EPICS, NICOS, etc.                                                   |
 | da00 | `da00_dataarray.fbs            ` | Pseudo-scipp DataArray with time-dependent and constant Variables                             |
 

--- a/schemas/fc00_forwarder_config.fbs
+++ b/schemas/fc00_forwarder_config.fbs
@@ -39,4 +39,4 @@ table ConfigUpdate {
     streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
 }
 
-root_type ConfigUpdate;
+root_type fc00_ConfigUpdate;

--- a/schemas/fc00_forwarder_config.fbs
+++ b/schemas/fc00_forwarder_config.fbs
@@ -31,7 +31,7 @@ table Stream {
   schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "tdct")
   topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
   protocol: Protocol = PVA;  // Protocol for channel, EPICS PV access by default
-  period: int32 = 0;         // Period for producing last value if there is no new data, 0 means only send new data
+  periodic: int32 = 0;         // Periodically producing last value if there is no new data, 0 means only send new data
 }
 
 table ConfigUpdate {

--- a/schemas/fc00_forwarder_config.fbs
+++ b/schemas/fc00_forwarder_config.fbs
@@ -31,10 +31,10 @@ table Stream {
   schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "tdct")
   topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
   protocol: Protocol = PVA;  // Protocol for channel, EPICS PV access by default
-  periodic: int = 0;         // Periodically producing last value if there is no new data, 0 means only send new data
+  periodic: int32 = 0;         // Periodically producing last value if there is no new data, 0 means only send new data
 }
 
-table ConfigUpdate {
+table fc00_ConfigUpdate {
     config_change: UpdateType;   // Type of config change, add streams, remove streams, remove all streams or replace (which works as remove all and add in one)
     streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
 }

--- a/schemas/fc00_forwarder_config.fbs
+++ b/schemas/fc00_forwarder_config.fbs
@@ -1,0 +1,42 @@
+// Forwarder Configuration Update
+// Add or remove channels from a Forwarder configuration
+//
+// Typical producers and consumers:
+// Produced by NICOS
+// Consumed by Forwarder
+
+file_identifier "fc00";
+
+enum UpdateType: ushort {
+  ADD,
+  REMOVE,
+  REMOVEALL,
+  REPLACE
+}
+
+enum Protocol: ushort {
+  PVA,  // EPICS PV access
+  CA,   // EPICS channel access
+  FAKE  // Forwarder generates fake updates, frequency configurable with command line argument
+}
+
+table Stream {
+  // If config_change=ADD then all fields of Stream must be populated.
+  // If config_change=REMOVE then at least one of the string fields must be populated,
+  // and the Forwarder will remove any streams which match all of the populated string fields.
+  // "populated" here means supplying a non-empty string for the field.
+  // Wildcards '?' (single character) and '*' (multi-character) can be used to match topic or channel name,
+  // Wildcards cannot be used to match schema as they are valid characters in schema identifiers.
+  channel: string;           // Name of the EPICS channel/pv (e.g. "MYIOC:VALUE1")
+  schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "tdct")
+  topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
+  protocol: Protocol = PVA;  // Protocol for channel, EPICS PV access by default
+  period: int32 = 0;         // Period for producing last value if there is no new data, 0 means only send new data
+}
+
+table ConfigUpdate {
+    config_change: UpdateType;   // Type of config change, add streams, remove streams, remove all streams or replace (which works as remove all and add in one)
+    streams: [Stream];           // Details what should be forwarded where, empty if config_change=REMOVEALL
+}
+
+root_type ConfigUpdate;

--- a/schemas/fc00_forwarder_config.fbs
+++ b/schemas/fc00_forwarder_config.fbs
@@ -31,7 +31,7 @@ table Stream {
   schema: string;            // Identify the output format for updates from the named channel (e.g. "f142" or "tdct")
   topic: string;             // Name of the output topic for updates from the named channel (e.g. "LOKI_motionControl")
   protocol: Protocol = PVA;  // Protocol for channel, EPICS PV access by default
-  periodic: int32 = 0;         // Periodically producing last value if there is no new data, 0 means only send new data
+  periodic: int = 0;         // Periodically producing last value if there is no new data, 0 means only send new data
 }
 
 table ConfigUpdate {


### PR DESCRIPTION
### Description of Work

We are adding a new filewriter config schema that allows us to configure whether certain PVs should be updated periodically or not. We also add the possibility of sending REPLACE, which automatically removes all streams and adds the new ones, instead of sending first a REMOVEALL and then ADD, which does have the risk of ending up in the wrong order.

### Issue

Closes (https://jira.esss.lu.se/browse/ECDC-4060)

### Developer Checklist

- [x] If there are new schema in this PR I have added them to the list in README.md
- [x] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [x] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.
