### PR TITLE
correct service_id field in wrdn

### DIFF
--- a/schemas/wrdn_finished_writing.fbs
+++ b/schemas/wrdn_finished_writing.fbs
@@ -3,7 +3,7 @@
 file_identifier "wrdn";
 
 table FinishedWriting {
-    service_id : string (required);     // milliseconds since Unix epoch (1 Jan 1970). When set to 0, will trigger a "stop NOW" code path in the file writer.
+    service_id : string (required);     // The identifier for the instance of the file-writer that has sent this update
     job_id : string (required);         // Uuid of the file writing job.
     error_encountered : bool;           // True if stopped due to error
     file_name : string (required);      // Name of file that was just closed.


### PR DESCRIPTION
### Description of Work

Corrects a comment for the `service_id` field in `wrdn` - this looked to be a copy-paste error from presumably another schema! 

### Issue

N/A

### Developer Checklist

- [ ] If there are new schema in this PR I have added them to the list in README.md
- [ ] If there are breaking changes to a schema, I have used a new file identifier and updated the list in README.md
- [ ] There is some documentation here or in the flat buffer file on the use case for this data, including which component is intended to send the data and/or which is the intended receiver.

## Approval Criteria

This PR should not be merged until the ECDC Group Leader (acting or permanent) has given their explicit approval in the comments section.
SCIPP/DRAM should also be consulted on changes which may affect them.
