### PR TITLE
Update vs00_strings.fbs

### DIFF
--- a/schemas/vs00_strings.fbs
+++ b/schemas/vs00_strings.fbs
@@ -3,9 +3,9 @@
 file_identifier "vs00";
 
 table vs00_StringData {
-    source_name: string (required);  // Field identifying the producer type, for example EPICS PV
-    timestamp: long (required);      // Nanoseconds since theUnix epoch
-    data: [string] (required);       // May be scalar or array
+    source_name: string;  // Field identifying the producer type, for example EPICS PV
+    timestamp: long;      // Nanoseconds since theUnix epoch
+    data: [string];       // May be scalar or array
 }
 
 root_type vs00_StringData;


### PR DESCRIPTION
remove requirements to comply with latest flatbuffers version

This patches vs00 so the streaming-data-type can be built; as a consequence, version is not bumped since there is currently no valid flatbuffer available